### PR TITLE
handling parent kwarg

### DIFF
--- a/src/widgetastic/widget.py
+++ b/src/widgetastic/widget.py
@@ -193,7 +193,8 @@ class Widget(six.with_metaclass(WidgetMetaclass, object)):
 
         This allows you a sort of Django-ish access to the defined widgets then.
         """
-        if args and isinstance(args[0], (Widget, Browser)):
+        if (args and isinstance(args[0], (Widget, Browser))) \
+                or ('parent' in kwargs and isinstance(kwargs['parent'], (Widget, Browser))):
             return super(Widget, cls).__new__(cls)
         else:
             return WidgetDescriptor(cls, *args, **kwargs)

--- a/testing/test_widget.py
+++ b/testing/test_widget.py
@@ -8,6 +8,7 @@ from widgetastic.widget import View, Widget, WidgetDescriptor
 def test_widget_correctly_collapses_to_descriptor(browser):
     assert isinstance(Widget(), WidgetDescriptor)
     assert isinstance(Widget(browser), Widget)
+    assert isinstance(Widget(parent=browser), Widget)
 
 
 def test_widget_browser(browser):


### PR DESCRIPTION
Widget can have parent either as a first argument of *args or as a kwargs['parent'].
Second case was forgotten.
It is really inobvious to pass parent as a first argument w/o name. 
So, I added it in order to make testing easier.
Example of testing, I usually do:

```
import widgetastic_manageiq as wm
view = navigate_to(provider, 'Timelines')
br = wm.BreadCrumb(parent=view)
br.active_location
reload(wm)
...
```