### PR TITLE
[RFR] Update Table and TableRow fill for row save

### DIFF
--- a/src/widgetastic/widget.py
+++ b/src/widgetastic/widget.py
@@ -1194,6 +1194,10 @@ class TableRow(Widget, ClickableMixin):
             else:
                 self.logger.info('Filling column %r', key)
 
+            # if the row widgets aren't visible the row needs to be clicked to edit
+            if not self[key].widget.is_displayed:
+                self.click()
+                changed = True
             if self[key].fill(value):
                 changed = True
         return changed
@@ -1654,7 +1658,7 @@ class Table(Widget):
                     fill_value = copy(fill_value)
                     fill_value[self.assoc_column_position] = key
                 if row.fill(fill_value):
-                    self.row_save()
+                    self.row_save(row=row.index)
                     changed = True
             return changed
         else:
@@ -1700,7 +1704,7 @@ class Table(Widget):
         raise NotImplementedError(
             'You need to implement the row_add in order to use dynamic adding')
 
-    def row_save(self):
+    def row_save(self, row=None):
         """To be implemented if the table has dynamic rows.
 
         Used when the table needs confirming saving of each row.

--- a/src/widgetastic/widget.py
+++ b/src/widgetastic/widget.py
@@ -1195,9 +1195,9 @@ class TableRow(Widget, ClickableMixin):
                 self.logger.info('Filling column %r', key)
 
             # if the row widgets aren't visible the row needs to be clicked to edit
-            if not self[key].widget.is_displayed:
-                self.click()
-                changed = True
+            if hasattr(self.parent, 'action_row') and getattr(self[key], 'widget', False):
+                if not self[key].widget.is_displayed:
+                    self.click()
             if self[key].fill(value):
                 changed = True
         return changed


### PR DESCRIPTION
Handles passing a row index to row_save to handle fill when an existing
row is found and edited.

Goes along with MIQ/Integration_tests DynamicTable implementation:
https://github.com/ManageIQ/integration_tests/pull/5048/files

Testing this against MIQ/CFME using PR 5048 linked above and a refactor of CFME's implementation of AnalysisProfile page.

https://github.com/ManageIQ/integration_tests/pull/4908

I'm able to cleanly update records in DynamicTable using `row_save`.

Still have a need for `row_delete`