### PR TITLE
[RFR] Update Widget.cls_widget_names, check values

### DIFF
--- a/src/widgetastic/widget.py
+++ b/src/widgetastic/widget.py
@@ -373,7 +373,9 @@ class Widget(six.with_metaclass(WidgetMetaclass, object)):
         for key in dir(cls):
             value = getattr(cls, key)
             if isinstance(value, Widgetable):
-                result.append((key, value))
+                # check the values of a VersionPick object are widgetable themselves
+                if all([isinstance(item, Widgetable) for item in value.child_items]):
+                    result.append((key, value))
         for includer in cls._included_widgets:
             result.append((None, includer))
         presorted_widgets = sorted(result, key=lambda pair: pair[1]._seq_id)

--- a/testing/test_version_pick.py
+++ b/testing/test_version_pick.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from six import string_types
 
 import pytest
 
@@ -73,10 +74,17 @@ def test_versionpick_on_view(browser):
             Version.lowest(): Checkbox(id='nonexisting'),
             '1.0.0': TextInput(name='input1')
         })
+        view_attr = VersionPick({
+            Version.lowest(): 'lowest_attr',
+            '1.0.0': 'version_1_attr'
+        })
 
     view = MyView(browser)
     assert 'widget' in view.widget_names
+    assert 'view_attr' not in view.widget_names
     assert isinstance(view.widget, TextInput)
+    assert isinstance(view.view_attr, string_types)
+    assert view.view_attr == 'version_1_attr'
     assert view.widget.fill('test text')
     assert view.widget.read() == 'test text'
 


### PR DESCRIPTION
Some views, like patternfly tabs, have class attributes with immutable
values that are version picked.

In widget.cls_widget_names, only the attribute value was checked for
Widgetable, which VersionPick is.

This adds a 2nd check, that the items in value.child_items are
themselves Widgetable, to catch when a VersionPick object includes a
non-widgetable immutable.

Should not impact existing uses where value is Widgetable, or is a
VersionPick object that includes widgets.

This verifies ALL items in VersionPick are widgetable, and only includes
the widget in widget_names if so.
  

Existing unit test has been updated to test the use of a View attribute that is not a widget.

I can't add reviewers or labels so I'm commenting with tags.
  