### PR TITLE
Fix the browser.py to support all chrome/mozilla/microsoft ED/IE version

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -8,7 +8,6 @@ import time
 
 from cached_property import cached_property
 from collections import namedtuple
-from jsmin import jsmin
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -559,31 +558,16 @@ class Browser(object):
         Returns:
             A :py:class:`set` of strings with classes.
         """
-        if self.browser_type in {'MicrosoftEdge', 'internet explorer'}:
-            # Kudos to psav who put together this little script
-            command = jsmin('''\
-                return (
-                    function(arguments){
-                        var arr=[];
-                        var le=arguments[0].classList.length;
-                        for (i=0; i < le; i++){
-                            arr.push(arguments[0].classList[i]);
-                        };
-                        return arr;
-                    })(arguments)''')
-        else:
-            # js classList call was changed for ff starting 46 version
-            if self.browser_version <= 45 and self.browser_type == 'firefox':
-                command = 'return arguments[0].classList;'
-            else:
-                command = 'return arguments[0].classList.value;'
-            script_run = self.execute_script(
-                command, self.element(locator, *args, **kwargs),
-                silent=True)
-            result = (set(re.split("\s+", script_run)) if isinstance(script_run, six.string_types)
-                      else set(script_run))
-            self.logger.debug('css classes for %r => %r', locator, result)
-            return result
+        command = '''return (arguments[0].classList.value) ?
+            arguments[0].classList.value : arguments[0].classList.toString();'''
+
+        script_run = self.execute_script(
+            command, self.element(locator, *args, **kwargs),
+            silent=True)
+        result = (set(re.split("\s+", script_run)) if isinstance(script_run, six.string_types)
+                  else set(script_run))
+        self.logger.debug('css classes for %r => %r', locator, result)
+        return result
 
     def tag(self, *args, **kwargs):
         """Returns the tag name of the element represented by the locator passed.


### PR DESCRIPTION
This PR is able to fix the `browser.py` to support running UI tests in the [Manageiq/integration_tests](https://github.com/ManageIQ/integration_tests).

The problem occurs because the[ Manageiq/integration_tests](https://github.com/ManageIQ/integration_tests) are using a chrome version 49 inside a docker selenium and the command  [`command = 'return arguments[0].classList.value;'`](https://github.com/RedHatQE/widgetastic.core/blob/master/src/widgetastic/browser.py#L579) the `.value` only exists after the version 50 of the chrome.

The error occurs when I tried to execute some UI test in the Integration test:

```
-------------------------------------------------------------------------------------------------------
self = <BrowserParentWrapper for VerticalNavigation('#maintab')>
locator = './ul/li[a[span[normalize-space(.)="Compute"]]]', args = ()
kwargs = {'parent': <selenium.webdriver.remote.webelement.WebElement (session="d64e779e-8f0f-439a-876d-350f968d66b2", element="9")>}
command = 'return arguments[0].classList.value;', script_run = None

    def classes(self, locator, *args, **kwargs):
        """Return a list of classes attached to the element.
    
            Args: See :py:meth:`elements`
    
            Returns:
                A :py:class:`set` of strings with classes.
            """
        if self.browser_type in {'MicrosoftEdge', 'internet explorer'}:
            # Kudos to psav who put together this little script
            command = jsmin('''\
                    return (
                        function(arguments){
                            var arr=[];
                            var le=arguments[0].classList.length;
                            for (i=0; i < le; i++){
                                arr.push(arguments[0].classList[i]);
                            };
                            return arr;
                        })(arguments)''')
        else:
            # js classList call was changed for ff starting 46 version
            if self.browser_version <= 45 and self.browser_type == 'firefox':
                command = 'return arguments[0].classList;'
            else:
                command = 'return arguments[0].classList.value;'
            script_run = self.execute_script(
                command, self.element(locator, *args, **kwargs),
                silent=True)
            result = (set(re.split("\s+", script_run)) if isinstance(script_run, six.string_types)
>                     else set(script_run))
E           TypeError: 'NoneType' object is not iterable

../cfme_venv/local/lib/python2.7/site-packages/widgetastic/browser.py:584: TypeError
```