### PR TITLE
Make widgetastic.utils.crop_string_middle py3-compatible

### DIFF
--- a/src/widgetastic/utils.py
+++ b/src/widgetastic/utils.py
@@ -594,7 +594,7 @@ def crop_string_middle(s, length=32, cropper='...'):
     """
     if len(s) <= length:
         return s
-    half = (length - len(cropper)) / 2
+    half = (length - len(cropper)) // 2
     return s[:half] + cropper + s[-half - 1:]
 
 


### PR DESCRIPTION
Before fix on py3:
```python
Python 3.6.4 (v3.6.4:d48ecebad5, Dec 18 2017, 21:07:28)

In [1]: from widgetastic.utils import crop_string_middle

In [2]: crop_string_middle('9311026077199426039824341772797765984569479798833999
   ...: 0444')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-90bd37e1b4c8> in <module>()
----> 1 crop_string_middle('93110260771994260398243417727977659845694797988339990444')

~/workspace/py3a/lib/python3.6/site-packages/widgetastic/utils.py in crop_string_middle(s, length, cropper)
    596         return s
    597     half = (length - len(cropper)) / 2
--> 598     return s[:half] + cropper + s[-half - 1:]
    599
    600

TypeError: slice indices must be integers or None or have an __index__ method
```

With fix applied, py3:
```python
Python 3.6.4 (v3.6.4:d48ecebad5, Dec 18 2017, 21:07:28)

In [1]: from widgetastic.utils import crop_string_middle

In [2]: crop_string_middle('9311026077199426039824341772797765984569479798833999
   ...: 0444')
Out[2]: '93110260771994...797988339990444'
```

Making sure py2 works as well:
```python
Python 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47)

In [1]: from widgetastic.utils import crop_string_middle

In [2]: crop_string_middle('9311026077199426039824341772797765984569479798833999
   ...: 0444')
Out[2]: u'93110260771994...797988339990444'
```