### PR TITLE
[WIPTEST] ignore_ajax value in after_click plugin

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -59,7 +59,7 @@ class DefaultPlugin(object):
 
         wait_for(_check, timeout=timeout, delay=0.2, very_quiet=True)
 
-    def after_click(self, element, locator):
+    def after_click(self, element, locator, ignore_ajax=None):
         """Invoked after clicking on an element."""
         pass
 
@@ -359,7 +359,7 @@ class Browser(object):
             except UnexpectedAlertPresentException:
                 pass
         try:
-            self.plugin.after_click(el, locator)
+            self.plugin.after_click(el, locator, ignore_ajax=ignore_ajax)
         except (StaleElementReferenceException, UnexpectedAlertPresentException):
             pass
 


### PR DESCRIPTION
Firefox closes any alert when some entity is accessed on page. so, we have to skip some code in after_click plugin if alert is displayed