### PR TITLE
Update browser.elements to take args/kwargs

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -217,7 +217,7 @@ class Browser(object):
     @retry_stale_element
     def elements(
             self, locator, parent=None, check_visibility=False, check_safe=True,
-            force_check_safe=False):
+            force_check_safe=False, *args, **kwargs):
         """Method that resolves locators into selenium webelements.
 
         Args:


### PR DESCRIPTION
Prevent TypeErrors from callers passing bundles of kwargs that don't apply.  Hitting some cases where force_scroll is passed erroneously, we can just ignore it here I think by taking kwargs.

I wouldn't go as far as calling this a 'fix'.