### PR TITLE
Move Table.table_tree to property

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -330,12 +330,14 @@ class Table(Widget):
         self.top_ignore_fill = top_ignore_fill
         self.bottom_ignore_fill = bottom_ignore_fill
 
+    @cached_property
+    def table_tree(self):
         if self.has_rowcolspan:
-            self.table_tree = self._process_table()
-            # column positions have to be recalculated because of all those references
-            self._recalc_column_positions(self.table_tree)
+            tmp_tree = self._process_table()
+            self._recalc_column_positions(tmp_tree)
+            return tmp_tree
         else:
-            self.table_tree = None
+            return None
 
     @cached_property
     def resolver(self):


### PR DESCRIPTION
Trying to check Table.has_rowcolspan during widget instantiation is causing issues when the widget is a sub-widget on something that requires child_widget_accessed.

For example, tables under wt.patternfly Tab class, during fill the widget gets instantiated and referenced before the child_widget_accessed method is called - so the table elements aren't found for rowcolspan check.