### PR TITLE
[RFR] Webdriverdownloader is replaced by webdrivermanager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
   - pip install -U pip
   - pip install -U setuptools
   - pip install -U tox tox-travis coveralls
-  - pip install git+https://github.com/quarckster/webdriverdownloader.git@geckodriver_fix
-  - webdriverdownloader firefox:v0.20.1
+  - pip install git+https://github.com/quarckster/webdriverdownloader.git@fix_github
+  - webdrivermanager firefox:v0.20.1
 script:
   - tox
 after_success:


### PR DESCRIPTION
Original repo seems abandoned, there is a fork https://github.com/rasjani/webdrivermanager.
Upd: the fork is also broken, so I pushed a PR with a fix https://github.com/rasjani/webdrivermanager/pull/4. Once it will be merged, it should be replaced by a package from pypi  https://pypi.org/project/webdrivermanager/