### PR TITLE
Enhance wait_displayed, new kwarg and return

### DIFF
--- a/src/widgetastic/widget/base.py
+++ b/src/widgetastic/widget/base.py
@@ -483,13 +483,15 @@ class Widget(six.with_metaclass(WidgetMetaclass, object)):
         return self.browser.is_displayed(self)
 
     @logged()
-    def wait_displayed(self, timeout='10s'):
+    def wait_displayed(self, timeout='10s', delay=0.2):
         """Wait for the element to be displayed. Uses the :py:meth:`is_displayed`
 
         Args:
-            timout: If you want, you can override the default timeout here
+            timeout: If you want, you can override the default timeout here
+            delay: override default delay for wait_for iterations
         """
-        wait_for(lambda: self.is_displayed, timeout=timeout, delay=0.2)
+        ret, _ = wait_for(lambda: self.is_displayed, timeout=timeout, delay=delay)
+        return ret
 
     @logged()
     def move_to(self):


### PR DESCRIPTION
Add delay kwarg to wait_displayed to pass through
Return the wait_for result of the last function execution

Returning allows for callers to assert against the wait_displayed call


seeing patterns for people doing:
```
wait_for(lambda view.is_displayed, delay=5s)  # they want to set the delay
assert view.is_displayed  # redundant, really, since we didn't hit TimedOutError

```
this will allow for callers to do:
```
assert view.wait_displayed(delay=5)
```