### PR TITLE
Ignore exceptions while waiting for element in Browser.wait_for_element

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -300,7 +300,8 @@ class Browser(object):
                 lambda: self.elements(locator, parent=parent, check_visibility=visible,
                                       check_safe=ensure_page_safe),
                 num_sec=timeout, delay=delay, fail_condition=lambda elements: not bool(elements),
-                fail_func=self.plugin.ensure_page_safe if ensure_page_safe else None)
+                fail_func=self.plugin.ensure_page_safe if ensure_page_safe else None,
+                handle_exception=True)
         except TimedOutError:
             if exception:
                 raise NoSuchElementException('Could not wait for element {!r}'.format(locator))


### PR DESCRIPTION
`wait_for_element` uses `wait_for` without `handle_exception=True` flag, which basically means if element is not there on first attempt - `NoSuchElementException` will be risen and no other attempts will be performed. That basically makes `wait_for_element` useless as it doesn't wait for element to appear :) Fixing that.