### PR TITLE
Update wait_for_element, change exception behavior

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -273,7 +273,7 @@ class Browser(object):
         return result
 
     def wait_for_element(
-            self, locator, parent=None, visible=False, timeout=5, delay=0.2, exception=True,
+            self, locator, parent=None, visible=False, timeout=5, delay=0.2, handle_exception=True,
             ensure_page_safe=False):
         """Wait for presence or visibility of elements specified by a locator.
 
@@ -283,31 +283,38 @@ class Browser(object):
                      also checks visibility.
             timeout: How long to wait for.
             delay: How often to check.
-            exception: If True (default), in case of element not being found an exception will be
-                       raised. If False, it returns False.
+            handle_exception: If True (default), NoSuchElementExceptions will be ignored until the wait is complete
+                              If false, the first NoSuchElementException will be immediately raised
             ensure_page_safe: Whether to call the ``ensure_page_safe`` hook on repeat.
 
         Returns:
             :py:class:`selenium.webdriver.remote.webelement.WebElement` if element found according
-            to params. ``None`` if not found and ``exception=False``.
+            to params.
 
         Raises:
             :py:class:`selenium.common.exceptions.NoSuchElementException` if element not found and
-            ``exception=True``.
+            ``handle_exception=False``.
+            :py:class:`wait_for.TimedOutError` if element not found and ``handle_exception=True``
         """
-        try:
-            result = wait_for(
-                lambda: self.elements(locator, parent=parent, check_visibility=visible,
-                                      check_safe=ensure_page_safe),
-                num_sec=timeout, delay=delay, fail_condition=lambda elements: not bool(elements),
-                fail_func=self.plugin.ensure_page_safe if ensure_page_safe else None)
-        except TimedOutError:
-            if exception:
-                raise NoSuchElementException('Could not wait for element {!r}'.format(locator))
-            else:
-                return None
-        else:
-            return result.out[0]
+        def _element_lookup():
+            try:
+                return self.elements(locator,
+                              parent=parent,
+                              check_visibility=visible,
+                              check_safe=ensure_page_safe)
+            except NoSuchElementException:
+                if not handle_exception:
+                    raise
+                else:
+                    return False
+        # could raise TimedOutError or NoSuchElement from _element_lookup
+        result = wait_for(_element_lookup,
+                          num_sec=timeout,
+                          delay=delay,
+                          fail_condition=lambda elements: not bool(elements),
+                          fail_func=self.plugin.ensure_page_safe if ensure_page_safe else None)
+        # wait_for returns NamedTuple, return first item from 'out', the WebElement
+        return result.out[0]
 
     def element(self, locator, *args, **kwargs):
         """Returns one :py:class:`selenium.webdriver.remote.webelement.WebElement`

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 import pytest
 
-from widgetastic.browser import BrowserParentWrapper
+from widgetastic.browser import BrowserParentWrapper, WebElement
 from widgetastic.exceptions import NoSuchElementException, LocatorNotImplemented
 from widgetastic.widget import View, Text
 
@@ -65,7 +65,10 @@ def test_elements_check_visibility(browser):
 def test_wait_for_element_visible(browser):
     # Click on the button
     browser.click('#invisible_appear_button')
-    assert browser.wait_for_element('#invisible_appear_p', visible=True) is not None
+    try:
+        assert isinstance(browser.wait_for_element('#invisible_appear_p', visible=True), WebElement)
+    except NoSuchElementException:
+        pytest.fail('NoSuchElementException raised when webelement expected')
 
 
 def test_wait_for_element_visible_fail_except(browser):
@@ -73,13 +76,6 @@ def test_wait_for_element_visible_fail_except(browser):
     browser.click('#invisible_appear_button')
     with pytest.raises(NoSuchElementException):
         browser.wait_for_element('#invisible_appear_p', visible=True, timeout=1.5)
-
-
-def test_wait_for_element_visible_fail_none(browser):
-    # Click on the button
-    browser.click('#invisible_appear_button')
-    assert browser.wait_for_element(
-        '#invisible_appear_p', visible=True, timeout=1.5, exception=False) is None
 
 
 def test_element_only_invisible(browser):


### PR DESCRIPTION
Proposed fix for wait_for_element behavior that @abalakh addressed in #130.

This is a slight refactor of the method, structuring it to more clearly handle exceptions (handle_exception param), and to raise TimedOutError or NoSuchElement depending on the given args and the failures encountered with the browser.