### PR TITLE
[RFR] Headers row can contain a td tag

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -314,7 +314,7 @@ class Table(Widget):
     """
     ROWS = './tbody/tr[./td]|./tr[not(./th) and ./td]'
     HEADER_IN_ROWS = './tbody/tr[1]/th'
-    HEADERS = './thead/tr/th|./tr/th' + '|' + HEADER_IN_ROWS
+    HEADERS = './thead/tr/th|./tr/th|./thead/tr/td' + '|' + HEADER_IN_ROWS
     ROW_AT_INDEX = './tbody/tr[{0}]|./tr[not(./th)][{0}]'
 
     ROOT = ParametrizedLocator('{@locator}')


### PR DESCRIPTION
Sometimes header can contain `td` instead of `th` and it's valid html. Example is here https://pf4.patternfly.org/components/Table/examples/