### PR TITLE
[RFR] Add ability to customize how table rows/columns are retrieved

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -69,7 +69,7 @@ class TableColumn(Widget, ClickableMixin):
         self.absolute_position = absolute_position  # absolute position according to row/colspan
 
     def __locator__(self):
-        return self.parent.table.COLUMN_AT_POSITION.format(self.position + 1),
+        return self.parent.table.COLUMN_AT_POSITION.format(self.position + 1)
 
     def __repr__(self):
         return '{}({!r}, {!r})'.format(type(self).__name__, self.parent, self.position)

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -214,7 +214,7 @@ class TableRow(Widget, ClickableMixin):
             )[0].obj
 
         else:
-            return self._create_column(self, index, logger=create_item_logger(self.logger, item))
+            return self.table._create_column(self, index, logger=create_item_logger(self.logger, item))
 
     def __getattr__(self, attr):
         try:

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -721,13 +721,13 @@ class Table(Widget):
                 raise ValueError('Unsupported action {}'.format(row_action))
 
         if query_parts and row_parts:
-            query = '{}[{}][{}]'.format(
+            query = '({})[{}][{}]'.format(
                 self.ROW_AT_INDEX.format('*'), ' and '.join(row_parts), ' and '.join(query_parts)
             )
         elif query_parts:
-            query = '{}[{}]'.format(self.ROW_AT_INDEX.format('*'), ' and '.join(query_parts))
+            query = '({})[{}]'.format(self.ROW_AT_INDEX.format('*'), ' and '.join(query_parts))
         elif row_parts:
-            query = '{}[{}]'.format(self.ROW_AT_INDEX.format('*'), ' and '.join(row_parts))
+            query = '({})[{}]'.format(self.ROW_AT_INDEX.format('*'), ' and '.join(row_parts))
         else:
             # When using ONLY regexps, we might see no query_parts, therefore default query
             query = self.ROW_AT_INDEX.format('*')

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -205,7 +205,6 @@ class TableRow(Widget, ClickableMixin):
 
         if self.table.table_tree:
             # We could find either a TableColumn or a TableReference node at this position...
-            # First look for a TableColumn element at this position
             cols = self.table.resolver.glob(
                 self.table.table_tree,
                 '{}[{}]{}[{}]'.format(
@@ -216,19 +215,6 @@ class TableRow(Widget, ClickableMixin):
                 ),
                 handle_resolver_error=True
             )
-            if not cols:
-                # Next look for a TableReference element at this position
-                cols.extend(
-                    self.table.resolver.glob(
-                        self.table.table_tree,
-                        '{}[{}]/ref[{}]'.format(
-                            self.table.ROW_RESOLVER_PATH,
-                            self.index,
-                            index
-                        ),
-                        handle_resolver_error=True
-                    )
-                )
             if not cols:
                 raise IndexError(
                     "Row {} has no TableColumn or TableReference node at position {}".format(
@@ -1048,7 +1034,7 @@ class Table(Widget):
                             ref_parent = node
                         ref_obj = TableReference(parent=ref_parent, reference=cur_obj)
                         ref_position = cur_position if col_step == 0 else cur_position + col_step
-                        Node(name='ref', parent=ref_parent, obj=ref_obj,
+                        Node(name=cur_tag, parent=ref_parent, obj=ref_obj,
                              position=ref_position)
 
                 else:
@@ -1061,8 +1047,6 @@ class Table(Widget):
             modifier = 0
             # Look for column nodes
             cols = self.resolver.glob(row, './{}'.format(self.COLUMN_RESOLVER_PATH))
-            # Look for TableReference nodes, not always guaranteed to be present
-            cols.extend(self.resolver.glob(row, './ref', handle_resolver_error=True))
             for col in sorted(cols, key=attrgetter('position')):
                 if getattr(col.obj, 'refers_to', None):
                     modifier -= 1

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -370,7 +370,7 @@ class Table(Widget):
         locator: A locator to the table ``<table>`` tag.
         column_widgets: A mapping to widgets that are present in cells. Keys signify column name,
             value is the widget definition.
-        assoc_column: Indexlooks or name of the column used for associative filling.
+        assoc_column: Index or name of the column used for associative filling.
         rows_ignore_top: Number of rows to ignore from top when reading/filling.
         rows_ignore_bottom: Number of rows to ignore from bottom when reading/filling.
         top_ignore_fill: Whether to also strip these top rows for fill.

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -187,7 +187,7 @@ class TableRow(Widget, ClickableMixin):
         return '{}({!r}, {!r})'.format(type(self).__name__, self.parent, self.index)
 
     def __locator__(self):
-        loc = self.parent.ROW_ELEMENT_PATH.format(self.index + 1)
+        loc = self.parent.ROW_AT_INDEX.format(self.index + 1)
         return self.browser.element(loc, parent=self.parent)
 
     def position_to_column_name(self, position):
@@ -214,7 +214,9 @@ class TableRow(Widget, ClickableMixin):
             )[0].obj
 
         else:
-            return self.table._create_column(self, index, logger=create_item_logger(self.logger, item))
+            return self.table._create_column(
+                self, index, logger=create_item_logger(self.logger, item)
+            )
 
     def __getattr__(self, attr):
         try:
@@ -728,8 +730,13 @@ class Table(Widget):
             # incorrect and has to be decreased
             # If the header is not in the body of the table, number of preceeding rows is 0-based
             # what is correct
-            rows.append(self._create_row(self, row_pos - 1 if self._is_header_in_body else row_pos,
-                                 logger=create_item_logger(self.logger, row_pos)))
+            rows.append(
+                self._create_row(
+                    self,
+                    row_pos - 1 if self._is_header_in_body else row_pos,
+                    logger=create_item_logger(self.logger, row_pos)
+                )
+            )
         return rows
 
     def _apply_row_filter(self, rows, row_filters):

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -69,10 +69,7 @@ class TableColumn(Widget, ClickableMixin):
         self.absolute_position = absolute_position  # absolute position according to row/colspan
 
     def __locator__(self):
-        return self.browser.element(
-            self.parent.table.COLUMN_AT_POSITION.format(self.position + 1),
-            parent=self.parent
-        )
+        return self.parent.table.COLUMN_AT_POSITION.format(self.position + 1),
 
     def __repr__(self):
         return '{}({!r}, {!r})'.format(type(self).__name__, self.parent, self.position)
@@ -188,8 +185,7 @@ class TableRow(Widget, ClickableMixin):
         return '{}({!r}, {!r})'.format(type(self).__name__, self.parent, self.index)
 
     def __locator__(self):
-        loc = self.parent.ROW_AT_INDEX.format(self.index + 1)
-        return self.browser.element(loc, parent=self.parent)
+        return self.parent.ROW_AT_INDEX.format(self.index + 1)
 
     def position_to_column_name(self, position):
         """Maps the position index into the column name (pretty)"""

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -53,9 +53,8 @@ def resolve_table_widget(parent, wcls):
 
     if isinstance(wcls, WidgetDescriptor):
         args = wcls.args
-        kwargs = wcls.kwargs
+        kwargs.update(wcls.kwargs)
         wcls = wcls.klass
-    kwargs = copy(kwargs)
     if 'logger' not in kwargs:
         kwargs['logger'] = create_child_logger(parent.logger, wcls.__name__)
     return wcls(parent, *args, **kwargs)

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -358,7 +358,7 @@ def test_table_multiple_tbody(browser):
 
         @property
         def is_displayed(self):
-            return self.browser.is_displayed(locator=self.ROW, parent=self)
+            return self.browser.is_displayed(self.ROW, parent=self)
 
     class TBodyTable(Table):
         ROWS = "./tbody"

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -388,7 +388,7 @@ def test_table_multiple_tbody(browser):
                 'Widget': TextInput(locator='./input'),
             }
         )
-    
+
     view = TestForm(browser)
 
     assert view.table1.headers == ('#',	'First Name', 'Last Name', 'Username', 'Widget')

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -5,7 +5,8 @@ import re
 
 from widgetastic.exceptions import DoNotReadThisWidget
 from widgetastic.widget import (
-    View, Table, Text, TextInput, FileInput, Checkbox, Select, ColourInput)
+    View, Table, Text, TextInput, FileInput, Checkbox, Select, ColourInput, Widget)
+from widgetastic.widget.table import TableRow
 from widgetastic.utils import Fillable, ParametrizedString, VersionPick, Version
 
 
@@ -335,6 +336,145 @@ def test_table(browser):
                                    u'Last Name': u'',
                                    u'Username': u'@blabla',
                                    u'Widget': u'widget6'}]
+
+
+def test_table_multiple_tbody(browser):
+    class TBodyRow(TableRow):
+        ROW = "./tr[1]"
+        HIDDEN_CONTENT = "./tr[2]/td[1]"
+
+        def __init__(self, parent, index, logger=None):
+            Widget.__init__(self, parent, logger=logger)
+            # We don't need to adjust index by +1 because anytree Node position will
+            # already be '+1' due to presence of 'thead' among the 'tbody' rows
+            self.index = index
+            self.hidden_content = Text(parent=self, locator=self.HIDDEN_CONTENT)
+
+        def __locator__(self):
+            # We don't need to adjust index by +1 because anytree Node position will
+            # already be '+1' due to presence of 'thead' among the 'tbody' rows
+            loc = self.parent.ROW_AT_INDEX.format(self.index)
+            return self.browser.element(loc, parent=self.parent)
+
+        @property
+        def is_displayed(self):
+            return self.browser.is_displayed(locator=self.ROW, parent=self)
+
+    class TBodyTable(Table):
+        ROWS = "./tbody"
+        ROW_RESOLVER_PATH = "/table/tbody"
+        ROW_AT_INDEX = "./tbody[{0}]"
+        COLUMN_RESOLVER_PATH = "/tr[0]/td"
+        COLUMN_AT_POSITION = "./tr[1]/td[{0}]"
+        ROW_TAG = "tbody"
+        Row = TBodyRow
+
+        @property
+        def _is_header_in_body(self):
+            """Override this to always return true.
+
+            Since we are resolving rows by the 'tbody' tag, widgetastic.Table._process_table
+            creates the rows with a position starting at 1 (because a <thead> tag is present
+            when enumerating through the <table> tag's children)
+            """
+            return True
+
+    class TestForm(View):
+        table1 = TBodyTable(
+            '#multiple_tbody_table',
+            column_widgets={
+                'First Name':  TextInput(locator='./input'),
+                'Last Name': TextInput(locator='./input'),
+                'Widget': TextInput(locator='./input'),
+            }
+        )
+    
+    view = TestForm(browser)
+
+    assert view.table1.headers == ('#',	'First Name', 'Last Name', 'Username', 'Widget')
+    assert len(list(view.table1.rows())) == 3
+
+    assert len(list(view.table1.rows(first_name='Mark'))) == 1
+    assert len(list(view.table1.rows(username__startswith='@slacker'))) == 1
+    assert len(list(view.table1.rows(first_name__startswith='Larry',
+                                     first_name__endswith='Bird'))) == 1
+    assert len(list(view.table1.rows(_row__attr=('data-test', 'def-345')))) == 1
+    assert len(list(view.table1.rows(_row__attr_startswith=('data-test', 'abc')))) == 2
+    assert len(list(view.table1.rows(_row__attr_endswith=('data-test', '345')))) == 2
+    assert len(list(view.table1.rows(_row__attr_contains=('data-test', '3')))) == 3
+    assert len(list(view.table1.rows(
+        _row__attr_contains=('data-test', '3'), _row__attr_startswith=('data-test', 'abc')))) == 2
+    assert len(list(view.table1.rows(_row__attr=('data-test', 'abc-345'), first_name='qwer'))) == 0
+
+    with pytest.raises(ValueError):
+        list(view.table1.rows(_row__papalala=('foo', 'bar')))
+
+    with pytest.raises(ValueError):
+        list(view.table1.rows(_row__attr_papalala=('foo', 'bar')))
+
+    with pytest.raises(ValueError):
+        list(view.table1.rows(_row__attr='foobar'))
+
+    assert len(list(view.table1.rows((0, '1')))) == 1
+    assert len(list(view.table1.rows((1, 'startswith', 'Jacob')))) == 1
+    assert len(list(view.table1.rows((1, 'startswith', 'Jacob'), username__endswith='at'))) == 1
+
+    assert len(list(view.table1.rows((1, re.compile(r'Mark$'))))) == 1
+    assert len(list(view.table1.rows((1, re.compile(r'^Jacob'))))) == 1
+    assert len(list(view.table1.rows(('Last Name', re.compile(r'^Otto'))))) == 1
+    assert len(list(view.table1.rows((0, re.compile(r'^2')), (3, re.compile(r'fat$'))))) == 1
+
+    row = view.table1.row(username='@slacker')
+    assert row[0].text == '3'
+    assert row['First Name'].text == 'Larry the Bird'
+    assert row.first_name.text == 'Larry the Bird'
+
+    assert row.read() == {u'#': u'3',
+                          u'First Name': u'Larry the Bird',
+                          u'Last Name': u'Larry the Bird',
+                          u'Username': u'@slacker',
+                          u'Widget': u'widget3'}
+
+    unpacking_fake_read = [(header, column.text) for header, column in row]
+    assert unpacking_fake_read == [(u'#', u'3'),
+                                   (u'First Name', u'Larry the Bird'),
+                                   (u'Last Name', u'Larry the Bird'),
+                                   (u'Username', u'@slacker'),
+                                   (u'Widget', u'')]
+
+    assert view.table1[1].last_name.text == 'Thornton'
+
+    with pytest.raises(AttributeError):
+        row.papalala
+
+    with pytest.raises(TypeError):
+        view.table1['boom!']
+
+    with pytest.raises(IndexError):
+        view.table1[1000]
+
+    row = next(view.table1.rows())
+    assert row.first_name.text == 'Mark'
+
+    assert view.table1.read() == [{u'#': u'1',
+                                   u'First Name': u'Mark',
+                                   u'Last Name': u'Otto',
+                                   u'Username': u'@mdo',
+                                   u'Widget': u'widget1'},
+                                  {u'#': u'2',
+                                   u'First Name': u'Jacob',
+                                   u'Last Name': u'Thornton',
+                                   u'Username': u'@fat',
+                                   u'Widget': u'widget2'},
+                                  {u'#': u'3',
+                                   u'First Name': u'Larry the Bird',
+                                   u'Last Name': u'Larry the Bird',
+                                   u'Username': u'@slacker',
+                                   u'Widget': u'widget3'}]
+
+    for row in view.table1:
+        assert row.is_displayed
+        assert not row.hidden_content.is_displayed
 
 
 def test_table_no_header(browser):

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -353,8 +353,7 @@ def test_table_multiple_tbody(browser):
         def __locator__(self):
             # We don't need to adjust index by +1 because anytree Node position will
             # already be '+1' due to presence of 'thead' among the 'tbody' rows
-            loc = self.parent.ROW_AT_INDEX.format(self.index)
-            return self.browser.element(loc, parent=self.parent)
+            return self.parent.ROW_AT_INDEX.format(self.index)
 
         @property
         def is_displayed(self):

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -248,8 +248,8 @@
         <th>Widget</th>
       </tr>
     </thead>
-    <tbody>
-      <tr data-test="abc-123">
+    <tbody data-test="abc-123">
+      <tr>
         <td>1</td>
         <td>Mark</td>
         <td>Otto</td>
@@ -260,8 +260,8 @@
         <td colspan="5"><p>some hidden content row 1</p></td>
       </tr>
     </tbody>
-    <tbody>
-      <tr data-test="abc-345">
+    <tbody data-test="abc-345">
+      <tr>
         <td>2</td>
         <td>Jacob</td>
         <td>Thornton</td>
@@ -272,8 +272,8 @@
         <td colspan="5"><p>some hidden content row 2</p></td>
       </tr>
     </tbody>
-    <tbody>
-      <tr data-test="def-345">
+    <tbody data-test="def-345">
+      <tr>
         <td>3</td>
         <td colspan="2">Larry the Bird</td>
         <td>@slacker</td>

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -237,5 +237,53 @@
     </tbody>
   </table>
 
+  <br><br>
+  <table class="table table-striped table-bordered" border="1" id="multiple_tbody_table">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Username</th>
+        <th>Widget</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr data-test="abc-123">
+        <td>1</td>
+        <td>Mark</td>
+        <td>Otto</td>
+        <td>@mdo</td>
+        <td><input name="widget1" type="text" value="widget1"></td>
+      </tr>
+      <tr hidden>
+        <td colspan="5"><p>some hidden content row 1</p></td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr data-test="abc-345">
+        <td>2</td>
+        <td>Jacob</td>
+        <td>Thornton</td>
+        <td>@fat</td>
+        <td><input name="widget2" type="text" value="widget2"></td>
+      </tr>
+      <tr hidden>
+        <td colspan="5"><p>some hidden content row 2</p></td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr data-test="def-345">
+        <td>3</td>
+        <td colspan="2">Larry the Bird</td>
+        <td>@slacker</td>
+        <td><input name="widget3" type="text" value="widget3"></td>
+      </tr>
+      <tr hidden>
+        <td colspan="5"><p>some hidden content row 3</p></td>
+      </tr>
+    </tbody>
+  </table>
+
 </body>
 </html>


### PR DESCRIPTION
In order to implement the Patternfly4 Expandable Table, we needed a way to change how the `Table` class calculates rows.

The Expandable Table uses a `<tbody>` for each row, with two `<tr>` tags within each tbody -- one of which is the row that is always visible, and the other is the "expanded content" visible when you expand the row. So, we need `Table` to find rows based on `tbody` instead of `tr`, and use a custom Row class.

This PR is intended to add more flexibility into `Table` so that changing the way it finds columns/rows can be manually configured if desired. Existing functionality is not supposed to change.

Changes made:
* Add class vars to allow custom defining of the node resolver paths and selenium browser paths for locating rows/columns
* Move the code that turns column `WidgetDescriptor`s into widgets with parent set to the `TableColumn` into a helper method so I can make use of this logic in widgetastic.pf4
* Don't skip `thead` in the tree. As far as I can tell, this should have no impact for normally structured tables since the table is always looking at the tree in `/table/tbody` anyways. However, removing this code *does* make a difference for me getting the row node positions correct for pf4 ExpandableTable.