### PR TITLE
[RFR] Fixes zero-indexed table bounds checking

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -459,9 +459,9 @@ class Table(Widget):
             at_index = row.index
         elif isinstance(item, int):
             at_index = item
-            if at_index > self.row_count:
-                raise IndexError('Integer row index {} is greater than row count {}'
-                                 .format(at_index, self.row_count))
+            if at_index >= self.row_count:
+                raise IndexError('Integer row index {} is greater than max index {}'
+                                 .format(at_index, self.row_count - 1))
         else:
             raise TypeError('Table [] accepts only strings or integers.')
         if at_index < 0:


### PR DESCRIPTION
Since https://github.com/RedHatQE/widgetastic.core/pull/125 tables have index from 0 but the check for max index value was not changed.

```python
In [5]: row = systems_table[3]

In [6]: row["Name"].text
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
widgetastic/browser.py in element(self, locator, *args, *kwargs)
    344             else:
--> 345                 return elements[0]
    346         except IndexError:

IndexError: list index out of range
```