### PR TITLE
Add caption property and support for ignoring tags when building tree

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -989,14 +989,8 @@ class Table(Widget):
         """Checks whether table has rowspan/colspan attributes"""
         return bool(self.browser.elements('./tbody//td[@rowspan or @colspan]', parent=self))
 
-    def _enumerate_children(self, children):
-        position = 0
-        for child in children:
-            # Ignore these tags when building table tree
-            if self.browser.tag(child) in self.IGNORE_TAGS:
-                continue
-            yield position, child
-            position += 1
+    def _filter_child(self, child):
+        return child.tag_name not in self.IGNORE_TAGS
 
     def _process_table(self):
         queue = deque()
@@ -1007,9 +1001,9 @@ class Table(Widget):
             node = queue.popleft()
             # visit node
             children = self.browser.elements('./*[descendant-or-self::node()]', parent=node.obj)
-            position = 0
-            for position, child in self._enumerate_children(children):
-                cur_tag = self.browser.tag(child)
+
+            for position, child in enumerate(filter(self._filter_child, children)):
+                cur_tag = child.tag_name
 
                 if cur_tag == self.ROW_TAG:
                     # todo: add logger

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -143,6 +143,7 @@ def test_table(browser):
     view = TestForm(browser)
     assert view.table.headers == (None, 'Column 1', 'Column 2', 'Column 3', 'Column 4')
     assert view.table1.headers == ('#',	'First Name', 'Last Name', 'Username', 'Widget')
+    assert view.table1.caption == "Some caption"
     dir(view.table[0])
     assert len(list(view.table.rows())) == 3
     assert len(list(view.table1.rows())) == 8
@@ -391,6 +392,7 @@ def test_table_multiple_tbody(browser):
     view = TestForm(browser)
 
     assert view.table1.headers == ('#',	'First Name', 'Last Name', 'Username', 'Widget')
+    assert view.table1.caption == "Some caption"
     assert len(list(view.table1.rows())) == 3
 
     assert len(list(view.table1.rows(first_name='Mark'))) == 1

--- a/testing/testing_page.html
+++ b/testing/testing_page.html
@@ -173,6 +173,7 @@
 </script>
 
  <table class="table table-striped table-bordered" border="1" id="rowcolspan_table">
+    <caption>Some caption</caption>
     <thead>
     <tr>
       <th>#</th>
@@ -239,6 +240,7 @@
 
   <br><br>
   <table class="table table-striped table-bordered" border="1" id="multiple_tbody_table">
+    <caption>Some caption</caption>
     <thead>
       <tr>
         <th>#</th>


### PR DESCRIPTION
Some tables have a `<caption>` tag (or perhaps other things defined underneath `<table>`, but I'm running into the caption tag at the moment) that may not be a row or header object. If we include those tags when building the table tree in `_process_table`, we keep increasing `position` which will throw off the index that the row is created with. So you end up with a `TableRow` with an incorrect xpath locator.

The idea here is to provide a list of tags that we will ignore when building the table tree. These will be skipped entirely and nodes won't be created for them, nor will position be incremented. So far the list only contains `caption`. It is a class var so its behavior can be changed if someone extends `Table`.