### PR TITLE
Ignore thead, tfoot, and colgroup tags when building table tree

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -385,7 +385,7 @@ class Table(Widget):
 
     # These tags are not added as Node objects to the table tree when
     # _process_table is called.
-    IGNORE_TAGS = ['caption']
+    IGNORE_TAGS = ['caption', 'thead', 'tfoot', 'colgroup']
 
     ROW_TAG = 'tr'
     COLUMN_TAG = 'td'

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -345,16 +345,8 @@ def test_table_multiple_tbody(browser):
         HIDDEN_CONTENT = "./tr[2]/td[1]"
 
         def __init__(self, parent, index, logger=None):
-            Widget.__init__(self, parent, logger=logger)
-            # We don't need to adjust index by +1 because anytree Node position will
-            # already be '+1' due to presence of 'thead' among the 'tbody' rows
-            self.index = index
+            super(TBodyRow, self).__init__(parent, index, logger=logger)
             self.hidden_content = Text(parent=self, locator=self.HIDDEN_CONTENT)
-
-        def __locator__(self):
-            # We don't need to adjust index by +1 because anytree Node position will
-            # already be '+1' due to presence of 'thead' among the 'tbody' rows
-            return self.parent.ROW_AT_INDEX.format(self.index)
 
         @property
         def is_displayed(self):
@@ -368,16 +360,6 @@ def test_table_multiple_tbody(browser):
         COLUMN_AT_POSITION = "./tr[1]/td[{0}]"
         ROW_TAG = "tbody"
         Row = TBodyRow
-
-        @property
-        def _is_header_in_body(self):
-            """Override this to always return true.
-
-            Since we are resolving rows by the 'tbody' tag, widgetastic.Table._process_table
-            creates the rows with a position starting at 1 (because a <thead> tag is present
-            when enumerating through the <table> tag's children)
-            """
-            return True
 
     class TestForm(View):
         table1 = TBodyTable(

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -5,7 +5,7 @@ import re
 
 from widgetastic.exceptions import DoNotReadThisWidget
 from widgetastic.widget import (
-    View, Table, Text, TextInput, FileInput, Checkbox, Select, ColourInput, Widget)
+    View, Table, Text, TextInput, FileInput, Checkbox, Select, ColourInput)
 from widgetastic.widget.table import TableRow
 from widgetastic.utils import Fillable, ParametrizedString, VersionPick, Version
 


### PR DESCRIPTION
Using `Table` with a ManageIQ `SummaryTable` was hitting an `IndexError: tuple index out of range` in `_process_table` when calling `_get_sibling_node` after the recent changes in v0.34

After adding some debug prints to `_process_table` we found out it is because while processing the first `tr` row within `tbody`, the node.parent was the `thead` tag instead of the `tbody`.
```
node is: tr
cur_tag td
ancestor is TableRow(Table('.//table', column_widgets={}, assoc_column=None, rows_ignore_top=None, rows_ignore_bottom=None), 0)
node.parent.children is (Node('/table/thead/tr', obj=TableRow(Table('.//table', column_widgets={}, assoc_column=None, rows_ignore_top=None, rows_ignore_bottom=None), 0), position=0),)
```

Ignoring the `<thead>` when building the table tree fixes this problem. We only care about the table body in the tree anyways, and the headers aren't located via the table tree. While I'm at it, I'm also ignoring other tags we might encounter under a `<table>` such as `<tfoot>` and `<colgroup>`. We already ignore `<caption>`