### PR TITLE
[RFR] fix tables derived from wt.core Table

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -395,7 +395,6 @@ class Table(Widget):
     ROOT = ParametrizedLocator('{@locator}')
 
     Row = TableRow
-    Column = TableColumn
 
     def __init__(
             self, parent, locator, column_widgets=None, assoc_column=None,
@@ -524,7 +523,7 @@ class Table(Widget):
 
     def _create_column(self, parent, position, absolute_position=None, logger=None):
         """Override this if you wish to change column behavior in a child class."""
-        return self.Column(parent, position, absolute_position, logger)
+        return self.Row.Column(parent, position, absolute_position, logger)
 
     def __getitem__(self, item):
         if isinstance(item, six.string_types):


### PR DESCRIPTION
fixing tables derived from wt.core Table. those got broken because those didn't override TableColumn in main Table class.

There are tables which override default TableRow and TableColumn. When Table had started using TableColumn directly, it broke all such overrides in other tables.  