### PR TITLE
Declutter some exceptions since we only do py3 + swap pypy for pypy3 in tox

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -202,7 +202,7 @@ class Browser(object):
                 if isinstance(loc, WebElement):
                     return loc
             raise LocatorNotImplemented(
-                'You have to implement __locator__ on {!r}'.format(type(locator)))
+                'You have to implement __locator__ on {!r}'.format(type(locator))) from None
 
     @staticmethod
     def _locator_force_visibility_check(locator):
@@ -310,7 +310,7 @@ class Browser(object):
         except TimedOutError:
             if exception:
                 raise NoSuchElementException('Failed waiting for element with {} in {}'
-                                             .format(locator, parent))
+                                             .format(locator, parent)) from None
             else:
                 return None
         # wait_for returns NamedTuple, return first item from 'out', the WebElement
@@ -341,7 +341,8 @@ class Browser(object):
             else:
                 return elements[0]
         except IndexError:
-            raise NoSuchElementException('Could not find an element {}'.format(repr(locator)))
+            raise NoSuchElementException(
+                'Could not find an element {}'.format(repr(locator))) from None
 
     def perform_click(self):
         """Clicks the left mouse button at the current mouse position."""
@@ -469,7 +470,7 @@ class Browser(object):
             except MoveTargetOutOfBoundsException:  # This has become desperate now.
                 raise MoveTargetOutOfBoundsException(
                     "Despite all the workarounds, scrolling to `{}` was unsuccessful.".format(
-                        locator))
+                        locator)) from None
         except WebDriverException as e:
             # Handling Edge weirdness
             if self.browser_type == 'MicrosoftEdge' and 'Invalid argument' in e.msg:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37},pypy,codechecks
+envlist = py{36,37},pypy3,codechecks
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -30,4 +30,4 @@ commands =
 [tox:travis]
 3.6 = py36
 3.7 = py37, codechecks
-pypy = pypy
+pypy3 = pypy3


### PR DESCRIPTION
Do not show the original exceptions that we are "repacking" to shorten the printouts.