### PR TITLE
[RFR] Visibility Optimization Fix

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import inspect
-from cached_property import cached_property
 from collections import namedtuple
+from textwrap import dedent
+
+from cached_property import cached_property
 from jsmin import jsmin
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -10,7 +12,6 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from smartloc import Locator
-from textwrap import dedent
 from wait_for import wait_for, TimedOutError
 
 from .exceptions import (
@@ -340,17 +341,15 @@ class Browser(object):
         """
         try:
             vcheck = self._locator_force_visibility_check(locator)
-            if vcheck is not None:
-                kwargs['check_visibility'] = vcheck
+            self.logger.error(vcheck)
+            kwargs['check_visibility'] = vcheck or kwargs.get('check_visibility', False)
             elements = self.elements(locator, *args, **kwargs)
             if len(elements) > 1:
-                visible_elements = [e for e in elements if self.is_displayed(e)]
-                if visible_elements:
-                    return visible_elements[0]
-                else:
-                    return elements[0]
-            else:
-                return elements[0]
+                if not kwargs['check_visibility']:
+                    visible_elements = [e for e in elements if self.is_displayed(e)]
+                    if visible_elements:
+                        return visible_elements[0]
+            return elements[0]
         except IndexError:
             raise NoSuchElementException(
                 'Could not find an element {}'.format(repr(locator))) from None

--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -341,14 +341,9 @@ class Browser(object):
         """
         try:
             vcheck = self._locator_force_visibility_check(locator)
-            self.logger.error(vcheck)
-            kwargs['check_visibility'] = vcheck or kwargs.get('check_visibility', False)
+            if vcheck is not None:
+                kwargs['check_visibility'] = vcheck
             elements = self.elements(locator, *args, **kwargs)
-            if len(elements) > 1:
-                if not kwargs['check_visibility']:
-                    visible_elements = [e for e in elements if self.is_displayed(e)]
-                    if visible_elements:
-                        return visible_elements[0]
             return elements[0]
         except IndexError:
             raise NoSuchElementException(

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -119,7 +119,9 @@ def test_element_only_visible(browser):
 
 
 def test_element_visible_after_invisible_and_classes_and_execute_script(browser):
-    assert 'visible' in browser.classes('//div[@id="visible_invisible"]/p', check_visibility=False)
+    assert 'invisible' in browser.classes(
+        '//div[@id="visible_invisible"]/p', check_visibility=False
+    )
 
 
 def test_element_nonexisting(browser):


### PR DESCRIPTION
* The current code can accidentally run a visibility check twice when multiple elements are requested via the wt.elements() call. This happens when the vcheck evaluates to True or when check_visibility is set to True and is not overidden.
* The fix shuffles some of the logic around a little, though it still seems a little weird that essentially when asking for multiple elements, we always do a visibility check anyway. I modified the code to prevent us doing the check twice, which on large sets of elements could be significant and will always result in a 50% time saving where it occurs.
* I think we need to revisit this section, especially as the code NEVER enforced a check for a single item.