### PR TITLE
[RFR] Reset table tree if table element changes

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -406,15 +406,22 @@ class Table(Widget):
         self.rows_ignore_bottom = rows_ignore_bottom
         self.top_ignore_fill = top_ignore_fill
         self.bottom_ignore_fill = bottom_ignore_fill
+        self.element_id = None
+        self._table_tree = None
 
-    @cached_property
+    def _get_table_tree(self):
+        current_element_id = self.browser.element(self).id
+        if not self._table_tree or current_element_id != self.element_id:
+            # no table tree processed yet, or the table at this locator has changed
+            self.element_id = current_element_id
+            tmp_tree = self._process_table()
+            self._table_tree = self._recalc_column_positions(tmp_tree)
+        return self._table_tree
+
+    @property
     def table_tree(self):
         if self.has_rowcolspan:
-            tmp_tree = self._process_table()
-            self._recalc_column_positions(tmp_tree)
-            return tmp_tree
-        else:
-            return None
+            return self._get_table_tree()
 
     @cached_property
     def resolver(self):

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -414,8 +414,8 @@ class Table(Widget):
         if not self._table_tree or current_element_id != self.element_id:
             # no table tree processed yet, or the table at this locator has changed
             self.element_id = current_element_id
-            tmp_tree = self._process_table()
-            self._table_tree = self._recalc_column_positions(tmp_tree)
+            self._table_tree = self._process_table()
+            self._recalc_column_positions(self._table_tree)
         return self._table_tree
 
     @property


### PR DESCRIPTION
We see cases where tables dynamically refresh on a page after selecting different filters or searching for items.

In these cases, the table has refreshed in the DOM but the table tree built by widgetastic is still cached in the Table instance. This means if you try to iterate over the rows of the table, if the number of rows has changed dynamically since the time the table tree was stored, the iterator won't correctly iterate on all the rows.

An example is:
* Table has 1 row
* User adjusts some "filter" on the page and now the table updates to have 3 rows.
* `[row.read() for row in table]` will only read 1 row instead of 3 rows.

This PR changes the table_tree property to check if the selenium element ID of the table has changed, and if so, the table tree is re-generated.