### PR TITLE
Align element in the center of the view

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -483,14 +483,14 @@ class Browser(object):
 
         # FF60+ doesn't raise MoveTargetOutOfBoundsException. it just silently does nothing
         if self.browser_type == 'firefox' and self.browser_version >= 60 and force_scroll:
-            self.execute_script("arguments[0].scrollIntoView();", el)
+            self.execute_script("arguments[0].scrollIntoView({block: 'center'});", el)
 
         move_to = ActionChains(self.selenium).move_to_element(el)
         try:
             move_to.perform()
         except MoveTargetOutOfBoundsException:
             # ff workaround
-            self.execute_script("arguments[0].scrollIntoView();", el)
+            self.execute_script("arguments[0].scrollIntoView({block: 'center'});", el)
             try:
                 move_to.perform()
             except MoveTargetOutOfBoundsException:  # This has become desperate now.


### PR DESCRIPTION
Current implementation aligns the top of the element to the top of the view. However, element can be obscured by e.g. sticky header (as shown in screenshot). Then, it is not possible to click on the element and it fails silently.
Therefore, it might be better to align the element to the center of the view.
![Screenshot from 2020-09-08 17-01-26](https://user-images.githubusercontent.com/14837841/92493741-26e45080-f1f5-11ea-9968-cf41b2e9595f.png)
