### PR TITLE
[RFR] Add copy and paste methods to Browser

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -762,6 +762,28 @@ class Browser(object):
         """
         ActionChains(self.selenium).send_keys(*keys).perform()
 
+    def copy(self, locator, *args, **kwargs):
+        """Select all and copy to clipboard."""
+        self.logger.debug('copy: %r', locator)
+        el = self.element(locator)
+        self.click(locator, *args, **kwargs)
+        self.plugin.before_keyboard_input(el, None)
+        ActionChains(self.selenium).key_down(Keys.CONTROL).send_keys('a').key_up(
+            Keys.CONTROL).perform()
+        ActionChains(self.selenium).key_down(Keys.CONTROL).send_keys('c').key_up(
+            Keys.CONTROL).perform()
+        self.plugin.after_keyboard_input(el, None)
+
+    def paste(self, locator, *args, **kwargs):
+        """Paste from clipboard to current element."""
+        self.logger.debug('paste: %r', locator)
+        el = self.element(locator)
+        self.click(locator, *args, **kwargs)
+        self.plugin.before_keyboard_input(el, None)
+        ActionChains(self.selenium).key_down(Keys.CONTROL).send_keys('v').key_up(
+            Keys.CONTROL).perform()
+        self.plugin.after_keyboard_input(el, None)
+
     def get_alert(self):
         """Returns the current alert object.
 

--- a/testing/html/testing_page.html
+++ b/testing/html/testing_page.html
@@ -33,6 +33,7 @@
     <option value="test" id="myoption">myoption</option>
   </select>
   <input type='text' id='input' />
+  <input type='text' id='input_paste' />
   <input type='file' id='fileinput' />
   <input type='color' id='colourinput' />
 

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -177,6 +177,15 @@ def test_simple_input_send_keys_clear(browser):
     assert browser.get_attribute('value', '#input') == ''
 
 
+def test_copy_paste(browser):
+    t = 'copy and paste text'
+    browser.send_keys(t, '#input')
+    assert browser.get_attribute('value', '#input') == t
+    browser.copy('#input')
+    browser.paste('#input_paste')
+    assert browser.get_attribute('value', '#input_paste') == t
+
+
 def test_nested_views_parent_injection(browser):
     class MyView(View):
         ROOT = '#proper'


### PR DESCRIPTION
This PR adds two new instance methods to `Browser`, for text/input-type widgets:

`copy()`: selects all content from the currently-selected element with `ctrl-A`, then copies it to the clipboard with `ctrl-C`.
`paste()`: pastes the content of the clipboard to the currently-selected element with `ctrl-V`.