### PR TITLE
Control webdriver container within tox

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -50,15 +50,18 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Set up Selenium Container
-      run: podman run -d --network host -p 4444:4444 --shm-size=2g quay.io/redhatqe/selenium-standalone:latest
+    - name: Get Webdriver Container
+      # tox-docker will run the container
+      run: |
+          docker pull quay.io/redhatqe/selenium-standalone:latest
 
     - name: UnitTest - Python-${{ matrix.python-version }}-${{ matrix.browser }}
       env:
         BROWSER: ${{ matrix.browser }}
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions setuptools
+        pip install setuptools
+        pip install -e .[development]
         tox
 
     - name: Upload coverage to Codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,13 @@ package_dir =
     =src
 packages = find:
 
+[options.extras_require]
+development =
+    pre-commit
+    tox
+    tox-docker
+    tox-gh-actions
+
 [options.packages.find]
 where = src
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,26 @@
 [tox]
 envlist = py{36,37,38},pypy3,codechecks
 
+[docker:quay.io/redhatqe/selenium-standalone]
+image = quay.io/redhatqe/selenium-standalone:latest
+ports = 4444:4444/tcp
+volumes = /dev/shm:/dev/shm
+
 [testenv]
 passenv = BROWSER
-deps=
-    pytest==4.6.4
+deps =
+    pytest==5.4.3
     pytest-localserver==0.5.0
-    pytest-cov==2.7.1
+    pytest-cov==2.10.1
     anytree
+docker =
+   quay.io/redhatqe/selenium-standalone
 commands =
-    py.test {posargs: -v --cov widgetastic --cov-report term-missing --cov-report xml --no-cov-on-fail -s}
+    py.test {posargs: -v -x --cov widgetastic --cov-report term-missing --cov-report xml --no-cov-on-fail -s}
 
 [testenv:codechecks]
 skip_install = true
-deps= pre-commit
+deps = pre-commit
 commands = pre-commit run --all
 
 [testenv:docs]


### PR DESCRIPTION
Trying to run tox locally, there is no execution of the webdriver container, or documentation that it needs to be run.

Historically travis ran this directly, and now the github workflow runs it.

There is a tox-docker plugin that allows for starting/stopping a container within the tox session.

THIS DOES NOT WORK YET
its running the container, but it is refusing webdriver connections
Need to debug further

opening PR to test the github workflow's ability to run the container

If this doesn't work out (tox-docker docs are already a bit off on the naming), I'll just be updating the docs to make it clear that you need to pull and run selenium-standalone if you want to run unit tests locally.