### PR TITLE
Fixed ReadTheDocs failed build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,8 @@ intersphinx_mapping = {
 
 templates_path = ['_templates']
 
+master_doc = 'index'
+
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
RTD failed to build docs due to:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/widgetastic/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 304, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/widgetastic/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 341, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/widgetastic/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 347, in build_update
    len(to_build))
  File "/home/docs/checkouts/readthedocs.org/user_builds/widgetastic/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 360, in build
    updated_docnames = set(self.read())
  File "/home/docs/checkouts/readthedocs.org/user_builds/widgetastic/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 472, in read
    self.env.doc2path(self.config.master_doc))
sphinx.errors.SphinxError: master file /home/docs/checkouts/readthedocs.org/user_builds/widgetastic/checkouts/latest/docs/contents.rst not found
Sphinx error:
master file /home/docs/checkouts/readthedocs.org/user_builds/widgetastic/checkouts/latest/docs/contents.rst not found
```
According to https://github.com/readthedocs/readthedocs.org/issues/2569 we need to adjust `conf.py` a bit.