### PR TITLE
Use chrome workaround for browser.clear() regardless of browser version

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -777,11 +777,7 @@ class Browser(object):
         el = self.element(locator, *args, **kwargs)
         self.plugin.before_keyboard_input(el, None)
         result = el.clear()
-        if (
-            el.get_attribute("value")
-            and self.browser_type == "chrome"
-            and self.browser_version >= 83
-        ):
+        if el.get_attribute("value") and self.browser_type == "chrome":
             # Chrome is not able to clear input with element.clear() method, use javascript instead
             # We need to click on element
             el.click()


### PR DESCRIPTION
This PR removes the check on chrome browser version when `browser.clear()` checks whether it should fall back on javascript commands after attempting to clear the field via the element's `clear()` method.

Prior to this PR, the fallback method was only done for chrome 83 and higher, but I see the same issue on chrome 76.