### PR TITLE
Highlight elements as we interact with them

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -131,6 +131,34 @@ class DefaultPlugin:
         """
         pass
 
+    def highlight_element(
+        self,
+        element: WebElement,
+        style: str = "border: 2px solid red;",
+        visible_for: float = 0.3,
+    ) -> None:
+        """
+        Highlight the passed element by directly changing it's style to the 'style' argument.
+
+        The new style will be visible for 'visible_for' [s] before reverting to the original style.
+
+        Generally, visible_for should not be > 0.5 s. If the timeout is too high and we check
+        an element multiple times in quick succession, the modified style will "stick".
+        """
+        self.browser.selenium.execute_script(
+            """
+            element = arguments[0];
+            original_style = element.getAttribute('style');
+            element.setAttribute('style', arguments[1]);
+            setTimeout(function(){
+                element.setAttribute('style', original_style);
+            }, arguments[2]);
+        """,
+            element,
+            style,
+            int(visible_for * 1000),
+        )  # convert visible_for to milliseconds
+
 
 class Browser:
     """Wrapper of the selenium "browser"
@@ -434,29 +462,6 @@ class Browser:
         """Double-clicks the left mouse button at the current mouse position."""
         ActionChains(self.selenium).double_click().perform()
 
-    def highlight_element(self, element, style="border: 2px solid red;", visible_for=0.3):
-        """
-        Highlight the passed element by directly changing it's style to the 'style' argument.
-
-        The new style will be visible for 'visible_for' [s] before reverting to the original style.
-
-        Generally, visible_for should not be > 0.5 s. If the timeout is too high and we check
-        an element multiple times in quick succession, the modified style will "stick".
-        """
-        self.selenium.execute_script(
-            """
-            element = arguments[0];
-            original_style = element.getAttribute('style');
-            element.setAttribute('style', arguments[1]);
-            setTimeout(function(){
-                element.setAttribute('style', original_style);
-            }, arguments[2]);
-        """,
-            element,
-            style,
-            int(visible_for * 1000),
-        )  # convert visible_for to milliseconds
-
     @retry_stale_element
     def click(self, locator: LocatorAlias, *args, **kwargs) -> None:
         """Clicks at a specific element using two separate events (mouse move, mouse click).
@@ -572,6 +577,7 @@ class Browser:
         """
         kw = kwargs.copy()
         force_scroll = kw.pop("force_scroll", False)
+        highlight_element = kw.pop("highlight_element", False)
         self.logger.debug("move_to_element: %r", locator)
         el = self.element(locator, *args, **kw)
         if el.tag_name == "option":
@@ -646,7 +652,8 @@ class Browser:
             else:
                 # Something else, never let it sink
                 raise
-        self.highlight_element(el)
+        if highlight_element:
+            self.plugin.highlight_element(el)
         return el
 
     def drag_and_drop(self, source: LocatorAlias, target: LocatorAlias) -> None:

--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -1,4 +1,5 @@
 import inspect
+import time
 from logging import Logger
 from textwrap import dedent
 from typing import Any
@@ -434,6 +435,28 @@ class Browser:
         """Double-clicks the left mouse button at the current mouse position."""
         ActionChains(self.selenium).double_click().perform()
 
+    def highlight_element(self, element, style="border: 2px solid red;", visible_for=0.3):
+        """
+        Highlight the passed element.
+        """
+
+        def _apply_style(el, s):
+            self.selenium.execute_script("arguments[0].setAttribute('style', arguments[1]);", el, s)
+
+        def _remove_highlight(element, original_style, visible_for=0.75):
+            # allow the highlight to show up for 'visible_for' s
+            time.sleep(visible_for)
+            try:
+                _apply_style(element, original_style)
+            except Exception:
+                # if we've navigated away or the element is no longer visible, just ignore it
+                pass
+
+        original_style = element.get_attribute("style")
+
+        _apply_style(element, style)
+        _remove_highlight(element, original_style, visible_for)
+
     @retry_stale_element
     def click(self, locator: LocatorAlias, *args, **kwargs) -> None:
         """Clicks at a specific element using two separate events (mouse move, mouse click).
@@ -623,6 +646,7 @@ class Browser:
             else:
                 # Something else, never let it sink
                 raise
+        self.highlight_element(el, visible_for=0.2)
         return el
 
     def drag_and_drop(self, source: LocatorAlias, target: LocatorAlias) -> None:


### PR DESCRIPTION
In writing UI tests locally, it is oftentimes difficult to get insight into what parts of a page selenium is touching. This PR changes the style of the current element to place a "red border" around it. This is particularly useful to see what parts of the page `is_displayed`/`am_i_here` methods are checking. 

~~However, in order for it to be useful the border must be visible for some small amount of time, which means a `time.sleep` and additional interaction time. I played around with various approaches~~:
- ~~trying to store the previous and current element and only restoring the style of the previous element when the current element changes~~
- ~~trying to restore the style of the element in a separate thread (and not waiting for the thread to complete). With this I found that the style oftentimes wasn't restored and the elements remained highlighted.~~

@quarckster @mshriver I'm curious what y'all think about this ~~and whether there's any good solution to having the highlight be visible. I don't want to unnecessarily increase test execution time.~~ I do think this would be beneficial when debugging tests locally or even if the highlights are able to be captured in a screenshot or test execution gif and uploaded to Ibutsu. Perhaps it could be an optional feature that's easy to enable locally. 

EDIT: I've just come across https://gist.github.com/marciomazza/3086536 which suggests using `setTimeout` in JS on the style. Let me try that out. 
EDIT (2): Just updated to use `setTimeout` and it works a lot better. 