### PR TITLE
read value property using Text on Input element

### DIFF
--- a/src/widgetastic/widget/text.py
+++ b/src/widgetastic/widget/text.py
@@ -13,5 +13,12 @@ class Text(GenericLocatorWidget):
     def text(self):
         return self.browser.text(self, parent=self.parent)
 
+    @property
+    def value(self):
+        return self.browser.element(self).get_attribute("value")
+
     def read(self):
         return self.text
+
+    def read_value(self):
+        return self.value


### PR DESCRIPTION
problem: Text element was used on `/input` locator, and the element has no text attribute and the text required is inside value attribute

This is my initial idea to just introduce new read_value property, which reads the value attribute of the element.

I am newbie here, so I will be happy for other ideas. 