### PR TITLE
Set default component_id to "" for OUIA base components

### DIFF
--- a/src/widgetastic/ouia/__init__.py
+++ b/src/widgetastic/ouia/__init__.py
@@ -30,7 +30,7 @@ class OUIABase:
     def _set_attrs(
         self,
         component_type: str,
-        component_id: Optional[str] = None,
+        component_id: str = "",
     ) -> None:
         self.component_type = quote(component_type)
         self.component_id = quote(component_id)
@@ -104,7 +104,7 @@ class OUIAGenericWidget(OUIABase, Widget, ClickableMixin):
     def __init__(
         self,
         parent: ViewParent,
-        component_id: Optional[str] = None,
+        component_id: str = "",
         logger: Optional[Logger] = None,
         component_type: Optional[str] = None,
     ) -> None:

--- a/testing/test_ouia.py
+++ b/testing/test_ouia.py
@@ -57,3 +57,13 @@ def test_safety(testing_view):
 def test_select(testing_view):
     testing_view.select.choose("first_option")
     testing_view.select.choose("second_option")
+
+
+def test_widget_without_id(browser):
+    class TestView(OUIAGenericView):
+        OUIA_COMPONENT_TYPE = "TestView"
+        button = Button()
+
+    view = TestView(browser)
+    assert view.is_displayed
+    assert view.button.locator == './/*[@data-ouia-component-type="PF/Button"]'


### PR DESCRIPTION
Using None as default values fails on the _set_attrs function as None cannot be quoted

Fixes #223