### PR TITLE
Added possibility to don't log sensitive data with sendkeys method

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -843,11 +843,12 @@ class Browser:
     def is_selected(self, *args, **kwargs) -> bool:
         return self.element(*args, **kwargs).is_selected()
 
-    def send_keys(self, text: str, locator: LocatorAlias, *args, **kwargs) -> None:
+    def send_keys(self, text: str, locator: LocatorAlias, sensitive=False, *args, **kwargs) -> None:
         """Sends keys to the element. Detects the file inputs automatically.
 
         Args:
             text: Text to be inserted to the element.
+            sensitive: Bool, If is set to True do not log sensitive data.
             *args: See :py:meth:`elements`
             **kwargs: See :py:meth:`elements`
         """
@@ -864,7 +865,7 @@ class Browser:
                 self.selenium.file_detector = LocalFileDetector()
             el = self.move_to_element(locator, *args, **kwargs)
             self.plugin.before_keyboard_input(el, text)
-            self.logger.debug("send_keys %r to %r", text, locator)
+            self.logger.debug("send_keys %r to %r", '*'*len(text) if sensitive else text, locator)
             result = el.send_keys(text)
             if Keys.ENTER not in text:
                 try:

--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -865,7 +865,7 @@ class Browser:
                 self.selenium.file_detector = LocalFileDetector()
             el = self.move_to_element(locator, *args, **kwargs)
             self.plugin.before_keyboard_input(el, text)
-            self.logger.debug("send_keys %r to %r", '*'*len(text) if sensitive else text, locator)
+            self.logger.debug("send_keys %r to %r", "*" * len(text) if sensitive else text, locator)
             result = el.send_keys(text)
             if Keys.ENTER not in text:
                 try:

--- a/src/widgetastic/widget/input.py
+++ b/src/widgetastic/widget/input.py
@@ -54,14 +54,19 @@ class TextInput(BaseInput):
     def read(self):
         return self.value
 
-    def fill(self, value):
+    def fill(self, value, sensitive=False):
+        """ Fill TextInput widget with value
+        Args:
+           value: Text to be filled into the input.
+           sensitive: Bool, If is set to True do not log sensitive data.
+        """
         current_value = self.value
         if value == current_value:
             return False
         # Clear and type everything
         self.browser.click(self)
         self.browser.clear(self)
-        self.browser.send_keys(value, self)
+        self.browser.send_keys(value, self, sensitive)
         return True
 
 

--- a/src/widgetastic/widget/input.py
+++ b/src/widgetastic/widget/input.py
@@ -55,7 +55,7 @@ class TextInput(BaseInput):
         return self.value
 
     def fill(self, value, sensitive=False):
-        """ Fill TextInput widget with value
+        """Fill TextInput widget with value
         Args:
            value: Text to be filled into the input.
            sensitive: Bool, If is set to True do not log sensitive data.


### PR DESCRIPTION
Sometimes you don't want to log sensitive data that are filled to inputs. For example, it would be useful when you need to upload a report but omit sensitive data from the logger inside.  PR adds this functionality by adding an option to the `send_keys` method.