### PR TITLE
Fix table resolver attribute error and local setup perm

### DIFF
--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -1169,7 +1169,7 @@ class TableResolver(Resolver):
     index_regexp = re.compile(r"(.*?)\[(\d+)\]$")
 
     def get(self, node, path):
-        node, parts = self._Resolver__start(node, path)
+        node, parts = self._Resolver__start(node, path, self._Resolver__cmp)
         for part in parts:
             if part == "..":
                 node = node.parent
@@ -1182,7 +1182,7 @@ class TableResolver(Resolver):
         return node
 
     def glob(self, node, path, handle_resolver_error=False):
-        node, parts = self._Resolver__start(node, path)
+        node, parts = self._Resolver__start(node, path, self._Resolver__cmp)
         try:
             return self.__glob(node, parts)
         except ResolverError:

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -61,7 +61,9 @@ def selenium_url(worker_id, browser_name, podman, pod):
         pod=pod.id,
         remove=True,
         name=f"selenium_{worker_id}",
+        environment={"SE_VNC_NO_PASSWORD": "1"},
     )
+
     container.start()
     yield f"http://{localhost_for_worker}:4444"
     container.remove(force=True)
@@ -79,6 +81,7 @@ def testing_page_url(worker_id, podman, pod):
                 "source": f"{os.getcwd()}/testing/html",
                 "target": "/usr/share/nginx/html",
                 "type": "bind",
+                "relabel": "Z",
             }
         ],
     )


### PR DESCRIPTION
- Fixed attribute error for table resolver
```
    def glob(self, node, path, handle_resolver_error=False):
>       node, parts = self._Resolver__start(node, path)
E       TypeError: __start() missing 1 required positional argument: 'cmp_'
```

- Added vnc connection without password
- Need permission to access mount files