### PR TITLE
workaround for #230: Modify pkg before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,12 @@ jobs:
           twine check dist/*
 
       - name: Deploy to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_wt_core }}
+#        uses: pypa/gh-action-pypi-publish@v1.4.1
+#        with:
+#          user: __token__
+#          password: ${{ secrets.pypi_wt_core }}
+        run: |
+          # Modify package as workaround for https://github.com/RedHatQE/widgetastic.core/issues/230
+          python .github/workflows/modpkg.py "${PWD}/dist"
+          twine check dist/*
+          twine upload dist/* --skip-existing --verbose -u  __token__ -p ${{ secrets.pypi_wt_core }}

--- a/.github/workflows/modpkg.py
+++ b/.github/workflows/modpkg.py
@@ -1,0 +1,30 @@
+import glob
+import os
+import shutil
+import sys
+from zipfile import ZipFile
+
+directory = sys.argv[1]
+original_name = "widgetastic_core"
+new_name = "widgetastic.core"
+print(f"dist folder holding whl file: {directory}")
+source_file = glob.glob(os.path.join(directory, f"{original_name}*.whl"))[0]
+target_file = source_file.replace(original_name, new_name)
+tempdir = os.path.join(directory, "temp")
+
+with ZipFile(source_file, "r") as source, ZipFile(target_file, "w") as target:
+    for item in source.infolist():
+        # Extract the original file to a temporary location
+        source.extract(item.filename, path=tempdir)
+        # Determine the new filename or directory name
+        if original_name in item.filename:
+            print(f"Renamed: {original_name} with {new_name}")
+            new_filename = item.filename.replace(original_name, new_name)
+        else:
+            new_filename = item.filename
+        target.write(os.path.join(tempdir, item.filename), arcname=new_filename)
+
+        # Remove the temporary extracted file or directory
+    os.remove(os.path.join(tempdir, item.filename))
+shutil.rmtree(tempdir)
+os.remove(source_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ readme = "README.rst"
 requires-python = ">=3.8"
 
 dependencies = [
-  "anytree",
+  "anytree >= 2.9.0",
   "cached_property",
   "selenium >= 4.0.0",
   "selenium-smart-locator",


### PR DESCRIPTION
Adding workaround for #230 
In my opinion, changing the package name is a permanent solution.
For now, adding a workaround my renaming the package whl file before uploading to PyPI.
