### PR TITLE
Set strict-naming=false for hatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,14 @@ requires = ["hatchling", "hatch-vcs"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/widgetastic"]
+# https://github.com/RedHatQE/widgetastic.core/issues/230
+strict-naming = false
+
+[tool.hatch.build.targets.sdist]
+packages = ["src/widgetastic"]
+# https://github.com/RedHatQE/widgetastic.core/issues/230
+strict-naming = false
+
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
This will build a wheel using the project name and unblock warehouse naming limitations from #230

Alternative approach to #239 

```                    

❯ hatch build
[sdist]
dist/widgetastic.core-1.0.4.dev1+gc4c81fe.tar.gz

[wheel]
dist/widgetastic.core-1.0.4.dev1+gc4c81fe-py3-none-any.whl


```


FIXES #230 