### PR TITLE
Don't log sensitive data with logged method

### DIFF
--- a/src/widgetastic/log.py
+++ b/src/widgetastic/log.py
@@ -30,8 +30,13 @@ def call_sig(args: Iterator[Any], kwargs: MutableMapping[str, Any]) -> str:
     Returns:
         A string that contains parameters in parentheses like the call to it.
     """
-    arglist = [repr(x) for x in args]
-    arglist.extend(f"{k}={v!r}" for k, v in kwargs.items())
+    safe_args = ["sensitive", "locator"]
+    if kwargs.get("sensitive"):
+        arglist = ["*" * len(repr(x)) for x in args]
+        arglist.extend(f"{k}={repr(v) if k in safe_args else '*' * len(repr(v))}" for k, v in kwargs.items())
+    else:
+        arglist = [repr(x) for x in args]
+        arglist.extend(f"{k}={v!r}" for k, v in kwargs.items())
     return "({args})".format(
         args=", ".join(arglist),
     )


### PR DESCRIPTION
`sensitive` parameter was introduced recently, but it was not reflected in log function decorator. This PR changes behaviour to hide all attributes except the safe ones.