### PR TITLE
Remove Unused Dependency: typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "cached_property",
   "selenium >= 4.0.0",
   "selenium-smart-locator",
-  "typing_extensions",
   "wait_for",
 ]
 


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `typing_extensions` from the `setup.cfg` configuration file. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `typing_extensions` library was originally introduced to the project  in #192  for its use in the `src/widgetastic/types.py` file. However, as of now, the said file (`src/widgetastic/types.py`) has been deleted, and the dependency  appears to be unused within the source code, while it continues to be listed in the project's dependency files. 
Removing this unused dependency  reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the typing_extensions dependency from `setup.cfg`.

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.
