### PR TITLE
ouia: use "contains" in xpath locator

### DIFF
--- a/src/widgetastic/ouia/__init__.py
+++ b/src/widgetastic/ouia/__init__.py
@@ -23,7 +23,7 @@ class OUIABase:
     """
 
     ROOT = ParametrizedLocator(
-        ".//*[@data-ouia-component-type={@component_type}{@component_id_suffix}]"
+        ".//*[contains(@data-ouia-component-type,{@component_type}){@component_id_suffix}]"
     )
     browser: Browser
 

--- a/testing/test_ouia.py
+++ b/testing/test_ouia.py
@@ -28,13 +28,13 @@ def test_ouia_view_without_id(browser):
 
     view = TestView(browser)
     assert view.is_displayed
-    assert view.locator == './/*[@data-ouia-component-type="TestView"]'
+    assert view.locator == './/*[contains(@data-ouia-component-type,"TestView")]'
 
 
 def test_ouia_view(testing_view):
     assert (
         testing_view.locator
-        == './/*[@data-ouia-component-type="TestView" and @data-ouia-component-id="ouia"]'
+        == './/*[contains(@data-ouia-component-type,"TestView") and @data-ouia-component-id="ouia"]'
     )
     assert testing_view.is_displayed
 
@@ -66,4 +66,4 @@ def test_widget_without_id(browser):
 
     view = TestView(browser)
     assert view.is_displayed
-    assert view.button.locator == './/*[@data-ouia-component-type="PF/Button"]'
+    assert view.button.locator == './/*[contains(@data-ouia-component-type,"PF/Button")]'


### PR DESCRIPTION
This allows to make widgetastic.patternfly5 ouia widgets backwards compatibl with PF4.