### PR TITLE
Move to release PyPI with a Trusted Publisher

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+# Note: Do not rename workflow name `deploy.ymal` as its used by trusted plublisher.
+
 name: 🐍  Publish to PyPI
 
 on:
@@ -14,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.12'
           architecture: 'x64'
 
       - name: Build Package and Check
@@ -29,7 +31,4 @@ jobs:
           twine check dist/*
 
       - name: Deploy to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_wt_core }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install Deps
         run: |
@@ -74,7 +74,7 @@ jobs:
         run: sphinx-build -b html -d build/sphinx-doctrees docs build/htmldocs
 
       - name: Archive Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sphinx-htmldocs
           path: build/htmldocs
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
           architecture: "x64"
 
       - name: Development setup on ${{ matrix.os }}
@@ -113,7 +113,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
           architecture: "x64"
 
       - name: Build and verify with twine


### PR DESCRIPTION
- Removed token
- Added trusted plublisher 
- Fixed: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3.
