### PR TITLE
move to latest selenium image

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,7 +14,7 @@ jobs:
   tests:
     # Run unit tests on different version of python and browser
     name: 🐍 Python-${{ matrix.python-version }}-${{ matrix.browser }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: [chrome, firefox]
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Pull selenium-standalone:latest
-        run: podman pull selenium/standalone-${{ matrix.browser }}:4.9
+        run: podman pull selenium/standalone-${{ matrix.browser }}:latest
 
       - name: Pull docker.io/library/nginx:alpine
         run: podman pull docker.io/library/nginx:alpine


### PR DESCRIPTION
This could go too far the opposite direction, but I'd rather see failures because of selenium updates than get a false sense of security from being on an older version.

Consumers of widgetastic will want to be on the latest version of selenium.

py3.12-chrome is failing on main branch, pulling the pause:3.5 image fails with 404. The image definitely exists