### PR TITLE
Latest chrome exception handling for invisible element in move_to_element

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -665,6 +665,12 @@ class Browser:
                 )
             ):
                 pass
+            elif (
+                self.browser_type == "chrome"
+                and self.browser_version >= 123
+                and ("has no size and location" in e.msg)
+            ):
+                pass
             else:
                 # Something else, never let it sink
                 raise


### PR DESCRIPTION
In chrome version 123 and later, calling `move_to_element` on a hidden element triggers a different exception:

Before:
```
selenium.common.exceptions.ElementNotInteractableException: Message: element not interactable: [object HTMLHeadingElement] has no size and location
```

After:
```
selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLHeadingElement] has no size and location"}
```

This PR updates `move_to_element` to handle it.

Before fix:
```
$ BROWSER=chrome pytest testing/test_browser.py
=== short test summary info ===
FAILED testing/test_browser.py::test_is_displayed_negative - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLHeadingElement] has no size and location"}
FAILED testing/test_browser.py::test_elements_check_visibility - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLParagraphElement] has no size and location"}
FAILED testing/test_browser.py::test_wait_for_element_visible - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLParagraphElement] has no size and location"}
FAILED testing/test_browser.py::test_wait_for_element_exception_control[with_exception] - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLParagraphElement] has no size and location"}
FAILED testing/test_browser.py::test_wait_for_element_exception_control[without_exception] - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLParagraphElement] has no size and location"}
FAILED testing/test_browser.py::test_element_force_visibility_check_by_locator - selenium.common.exceptions.JavascriptException: Message: javascript error: {"status":60,"value":"[object HTMLHeadingElement] has no size and location"}
=== 6 failed, 39 passed in 22.25s ===
```

After:
```
$ BROWSER=chrome pytest testing/test_browser.py
[...]
=== 45 passed in 30.39s ===
```