### PR TITLE
Fix clear input for number type

### DIFF
--- a/testing/html/testing_page.html
+++ b/testing/html/testing_page.html
@@ -34,6 +34,7 @@
   </select>
   <input type='text' id='input' />
   <input type='text' id='input_paste' />
+  <input type='number' id='input_number' />
   <input type='file' id='fileinput' />
   <input type='color' id='colourinput' />
 

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -181,6 +181,13 @@ def test_simple_input_send_keys_clear(browser):
     assert browser.get_attribute("value", "#input") == ""
 
 
+def test_clear_input_type_number(browser):
+    browser.send_keys("3", "#input_number")
+    assert browser.get_attribute("value", "#input_number") == "3"
+    browser.clear("#input_number")
+    assert browser.get_attribute("value", "#input") == ""
+
+
 def test_copy_paste(browser):
     t = "copy and paste text"
     browser.send_keys(t, "#input")


### PR DESCRIPTION
`Ctrl + A` is generally used to select text. In number input fields, the browser does not treat the numeric value as selectable text, which is why `Ctrl + A` doesn't work.

Bug has been found when debugging test that tries to navigate to specific page using pagination input