### PR TITLE
Removing x as it is unnecessary in the value

### DIFF
--- a/src/widgetastic/widget/base.py
+++ b/src/widgetastic/widget/base.py
@@ -841,6 +841,11 @@ class ConditionalSwitchableView(Widgetable):
                             ref_o = nested_getattr(o, self.reference)
                             if isinstance(ref_o, Widget):
                                 ref_value = ref_o.read()
+                                ref_value = (
+                                    ref_value.split(" ")[1]
+                                    if ref_value.startswith("×")
+                                    else ref_value
+                                )
                             else:
                                 ref_value = ref_o
                             condition_arg_cache[self.reference] = ref_value


### PR DESCRIPTION
Most dropdown options include a clear option represented by the `x` symbol. However, when fetching a value from the dropdown in automation, the retrieved text appears for example as `× Kickstart default finish`, where the extra `×` is unnecessary in text. This issue is causing multiple automation tests to fail. Adding a fix in `ConditionalSwitchableView class` to ensure the text is fetched correctly like `Kickstart default finish`, preventing failures caused by incorrect text.


