### PR TITLE
Correcting the copyright notice to Red Hat, Inc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,10 @@ from datetime import datetime
 # -- Project information -----------------------------------------------------
 
 project = "widgetastic.core"
-copyright = f"2016-{datetime.now().year}, Milan Falešník (Apache license 2)"
-author = "Milan Falešník"
+copyright = (
+    f"2016-2019, Milan Falešník; 2020-{datetime.now().year}, Red Hat, Inc. (Apache license 2)"
+)
+author = "Milan Falešník, Red Hat, Inc."
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Correcting the copyright notice to Red Hat, Inc. to prevent confusion. This aligns the documentation with the project's license and honors the original author contributions up to 2019.