### PR TITLE
Adding value_of_css_property method

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - playwright
+      - main
   pull_request:
     types: ["opened", "synchronize", "reopened"]
   schedule:

--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -790,6 +790,28 @@ class Browser:
         )
         self.logger.debug("set attribute for %r => %r=%r", args, attr, value)
 
+    def value_of_css_property(
+        self, locator: LocatorAlias, property: str, *args, **kwargs
+    ) -> Optional[str]:
+        """Retrieves the value of specified computed style property of an element in the current browsing context.
+
+        Args:
+            locator: Element locator to get css property
+            property: CSS property to get the value of
+            *args: Additional arguments passed to element() method
+            **kwargs: Additional keyword arguments passed to element() method
+
+        Returns:
+            Value of css property.
+        """
+        self.logger.debug(
+            "Retrieving value of css property '%s' for locator: %r", property, locator
+        )
+        el = self.element(locator, *args, **kwargs)
+        return el.evaluate(
+            f"element => window.getComputedStyle(element).getPropertyValue('{property}')"
+        )
+
     # ================== ELEMENT GEOMETRY & VISUAL PROPERTIES ==================
     def size_of(self, *args, **kwargs) -> Size:
         """Returns element's size as a tuple of width/height.

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -97,7 +97,7 @@ def playwright_browser_instance(
 def browser_context(playwright_browser_instance: PlaywrightBrowser) -> BrowserContext:
     """Creates a browser context for the entire test session."""
     context = playwright_browser_instance.new_context(
-        viewport={"width": 1280, "height": 720},
+        viewport={"width": 1920, "height": 1080},
     )
     yield context
     context.close()

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -533,6 +533,14 @@ def test_set_attribute(browser):
     assert browser.get_attribute("foo", "#invisible") == "bar"
 
 
+def test_value_of_css_property(browser):
+    assert browser.value_of_css_property(locator="#test-image-full", property="margin") == "5px"
+    assert (
+        browser.value_of_css_property(locator="#test-image-full", property="border-color")
+        == "rgb(221, 221, 221)"
+    )
+
+
 # ================== ELEMENT GEOMETRY & VISUAL PROPERTIES TESTS ==================
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add a new method to retrieve computed CSS property values of elements, validate it with tests, and update test viewport dimensions

New Features:
- Introduce value_of_css_property method to fetch computed CSS property values

Enhancements:
- Update default test viewport size to 1920x1080

Tests:
- Add tests for value_of_css_property using margin and border-color properties