### PR TITLE
Use timeout with int instead of num_sec

### DIFF
--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -99,7 +99,7 @@ class DefaultPlugin:
         """Logger with prepended plugin name."""
         return create_widget_logger(type(self).__name__, self.browser.logger)
 
-    def ensure_page_safe(self, timeout: str = "10s") -> None:
+    def ensure_page_safe(self, timeout=10) -> None:
         # THIS ONE SHOULD ALWAYS USE JAVASCRIPT ONLY, NO OTHER SELENIUM INTERACTION
 
         def _check():
@@ -431,7 +431,7 @@ class Browser:
         try:
             result = wait_for(
                 _element_lookup,
-                num_sec=timeout,
+                timeout=timeout,
                 delay=delay,
                 fail_condition=lambda elements: not bool(elements),
                 fail_func=self.plugin.ensure_page_safe if ensure_page_safe else None,

--- a/src/widgetastic/utils.py
+++ b/src/widgetastic/utils.py
@@ -763,7 +763,7 @@ class WaitFillViewStrategy(DefaultFillViewStrategy):
     So such strategy gives next widget some time to turn up.
     """
 
-    def __init__(self, respect_parent=False, wait_widget="5s"):
+    def __init__(self, respect_parent=False, wait_widget=5):
         self.wait_widget = wait_widget
         super().__init__(respect_parent=respect_parent)
 

--- a/src/widgetastic/widget/base.py
+++ b/src/widgetastic/widget/base.py
@@ -523,7 +523,7 @@ class Widget(metaclass=WidgetMetaclass):
         return self.browser.element(self).is_enabled()
 
     @logged()
-    def wait_displayed(self, timeout="10s", delay=0.2):
+    def wait_displayed(self, timeout=10, delay=0.2):
         """Wait for the element to be displayed. Uses the :py:meth:`is_displayed`
 
         Args:


### PR DESCRIPTION
This PR is CP of for `legacy-selenium-support` branch that is used in https://github.com/SatelliteQE/airgun.

From the parent PR:
The timeout kwarg should be an integer, float, or timedelta instance

Also, num_sec will be deprecated.

## Summary by Sourcery

Standardize timeout handling on integer-based `timeout` parameters instead of string-based or `num_sec` arguments across browser safety checks, element lookup, and wait strategies.

Enhancements:
- Update widget and browser APIs to use numeric timeout defaults instead of string durations.
- Switch internal wait calls from the deprecated `num_sec` parameter to the `timeout` parameter for consistency with the underlying wait utility.