### PR TITLE
Fix/pypi strict naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.16.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - '--fix'
       - id: ruff-format
@@ -13,6 +13,6 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+    rev: v2.3.0
     hooks:
       - id: mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 # -- Project information -----------------------------------------------------
 
 project = "widgetastic.core"
 copyright = (
-    f"2016-2019, Milan Falešník; 2020-{datetime.now().year}, Red Hat, Inc. (Apache license 2)"
+    f"2016-2019, Milan Falešník; 2020-{datetime.now(tz=timezone.utc).year}, "
+    "Red Hat, Inc. (Apache license 2)"
 )
 author = "Milan Falešník, Red Hat, Inc."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,9 @@ requires = ["hatchling", "hatch-vcs"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/widgetastic"]
-# https://github.com/RedHatQE/widgetastic.core/issues/230
-strict-naming = false
 
 [tool.hatch.build.targets.sdist]
 packages = ["src/widgetastic"]
-# https://github.com/RedHatQE/widgetastic.core/issues/230
-strict-naming = false
 
 
 [tool.hatch.version]

--- a/src/widgetastic/browser.py
+++ b/src/widgetastic/browser.py
@@ -1,46 +1,35 @@
+from __future__ import annotations
+
 import inspect
 from logging import Logger
 from textwrap import dedent
-from typing import Any
-from typing import cast
-from typing import Dict
-from typing import List
-from typing import NamedTuple
-from typing import Optional
-from typing import Set
-from typing import Type
-from typing import TYPE_CHECKING
-from typing import Union
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from cached_property import cached_property
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.alert import Alert
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.remote.file_detector import LocalFileDetector
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector, UselessFileDetector
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from smartloc import Locator
-from wait_for import TimedOutError
-from wait_for import wait_for
+from wait_for import TimedOutError, wait_for
 
-from .exceptions import ElementNotInteractableException
-from .exceptions import LocatorNotImplemented
-from .exceptions import MoveTargetOutOfBoundsException
-from .exceptions import NoAlertPresentException
-from .exceptions import NoSuchElementException
-from .exceptions import StaleElementReferenceException
-from .exceptions import UnexpectedAlertPresentException
-from .exceptions import WebDriverException
-from .log import create_widget_logger
-from .log import null_logger
-from .types import ElementParent
-from .types import LocatorAlias
-from .types import LocatorProtocol
-from .utils import crop_string_middle
-from .utils import retry_stale_element
+from .exceptions import (
+    ElementNotInteractableException,
+    LocatorNotImplemented,
+    MoveTargetOutOfBoundsException,
+    NoAlertPresentException,
+    NoSuchElementException,
+    StaleElementReferenceException,
+    UnexpectedAlertPresentException,
+    WebDriverException,
+)
+from .log import create_widget_logger, null_logger
+from .types import ElementParent, LocatorAlias, LocatorProtocol
+from .utils import crop_string_middle, retry_stale_element
 from .xpath import normalize_space
 
 EXTRACT_CLASSES_OF_ELEMENT = """
@@ -91,7 +80,7 @@ class DefaultPlugin:
         }
         """
 
-    def __init__(self, browser: "Browser") -> None:
+    def __init__(self, browser: Browser) -> None:
         self.browser = browser
 
     @cached_property
@@ -114,31 +103,26 @@ class DefaultPlugin:
 
     def after_click(self, element: WebElement, locator: LocatorAlias) -> None:
         """Invoked after clicking on an element."""
-        pass
 
     def after_click_safe_timeout(self, element: WebElement, locator: LocatorAlias) -> None:
         """Invoked after clicking on an element and :py:meth:`ensure_page_safe` failing to wait."""
-        pass
 
     def before_click(self, element: WebElement, locator: LocatorAlias) -> None:
         """Invoked before clicking on an element."""
-        pass
 
-    def after_keyboard_input(self, element: WebElement, keyboard_input: Optional[str]) -> None:
+    def after_keyboard_input(self, element: WebElement, keyboard_input: str | None) -> None:
         """Invoked after sending keys into an element.
 
         Args:
             keyboard_input: String if any text typed in, None if the element is cleared.
         """
-        pass
 
-    def before_keyboard_input(self, element: WebElement, keyboard_input: Optional[str]) -> None:
+    def before_keyboard_input(self, element: WebElement, keyboard_input: str | None) -> None:
         """Invoked after sending keys into an element.
 
         Args:
             keyboard_input: String if any text typed in, None if the element is cleared.
         """
-        pass
 
     def highlight_element(
         self,
@@ -226,9 +210,9 @@ class Browser:
     def __init__(
         self,
         selenium: WebDriver,
-        plugin_class: Optional[Type[DefaultPlugin]] = None,
-        logger: Optional[Logger] = None,
-        extra_objects: Optional[Dict[Any, Any]] = None,
+        plugin_class: type[DefaultPlugin] | None = None,
+        logger: Logger | None = None,
+        extra_objects: dict[Any, Any] | None = None,
     ) -> None:
         self.selenium = selenium
         plugin_class = plugin_class or DefaultPlugin
@@ -272,13 +256,13 @@ class Browser:
         return int(version.split(".")[0])
 
     @property
-    def browser(self) -> "Browser":
+    def browser(self) -> Browser:
         """Implemented so :py:class:`widgetastic.widget.View` does not have to check the
         instance of its parent. This property exists there so here it just stops the chain"""
         return self
 
     @property
-    def root_browser(self) -> "Browser":
+    def root_browser(self) -> Browser:
         return self
 
     @property
@@ -290,7 +274,7 @@ class Browser:
         raise NotImplementedError("You have to implement product_version")
 
     @staticmethod
-    def _process_locator(locator: LocatorAlias) -> Union[WebElement, Locator]:
+    def _process_locator(locator: LocatorAlias) -> WebElement | Locator:
         """Processes the locator so the :py:meth:`elements` gets exactly what it needs."""
         if isinstance(locator, WebElement):
             return locator
@@ -310,7 +294,7 @@ class Browser:
             ) from None
 
     @staticmethod
-    def _locator_force_visibility_check(locator: LocatorAlias) -> Optional[bool]:
+    def _locator_force_visibility_check(locator: LocatorAlias) -> bool | None:
         if hasattr(locator, "__locator__") and hasattr(locator, "CHECK_VISIBILITY"):
             return cast(LocatorProtocol, locator).CHECK_VISIBILITY
         else:
@@ -320,13 +304,13 @@ class Browser:
     def elements(
         self,
         locator: LocatorAlias,
-        parent: Optional[ElementParent] = None,
+        parent: ElementParent | None = None,
         check_visibility: bool = False,
         check_safe: bool = True,
         force_check_safe: bool = False,
         *args,
         **kwargs,
-    ) -> List[WebElement]:
+    ) -> list[WebElement]:
         """Method that resolves locators into selenium webelements.
 
         Args:
@@ -388,13 +372,13 @@ class Browser:
     def wait_for_element(
         self,
         locator: str,
-        parent: Optional[ElementParent] = None,
+        parent: ElementParent | None = None,
         visible: bool = False,
-        timeout: Union[float, int] = 5,
+        timeout: float = 5,
         delay: float = 0.2,
         exception: bool = True,
         ensure_page_safe: bool = False,
-    ) -> Optional[WebElement]:
+    ) -> WebElement | None:
         """Wait for presence or visibility of elements specified by a locator.
 
         Args:
@@ -464,7 +448,7 @@ class Browser:
             elements = self.elements(locator, *args, **kwargs)
             return elements[0]
         except IndexError:
-            raise NoSuchElementException(f"Could not find an element {repr(locator)}") from None
+            raise NoSuchElementException(f"Could not find an element {locator!r}") from None
 
     def perform_click(self) -> None:
         """Clicks the left mouse button at the current mouse position."""
@@ -483,7 +467,7 @@ class Browser:
         self.logger.debug("click: %r", locator)
         ignore_ajax = kwargs.pop("ignore_ajax", False)
         force_scroll = self.browser_type == "firefox"
-        el = self.move_to_element(locator, force_scroll=force_scroll, *args, **kwargs)
+        el = self.move_to_element(locator, *args, force_scroll=force_scroll, **kwargs)
         self.plugin.before_click(el, locator)
         # and then click on current mouse position
         self.perform_click()
@@ -513,7 +497,7 @@ class Browser:
         self.logger.debug("double_click: %r", locator)
         ignore_ajax = kwargs.pop("ignore_ajax", False)
         force_scroll = self.browser_type == "firefox"
-        el = self.move_to_element(locator, force_scroll=force_scroll, *args, **kwargs)
+        el = self.move_to_element(locator, *args, force_scroll=force_scroll, **kwargs)
         self.plugin.before_click(el, locator)
         # and then click on current mouse position
         self.perform_double_click()
@@ -617,9 +601,7 @@ class Browser:
                 move_to.perform()
             except MoveTargetOutOfBoundsException:  # This has become desperate now.
                 raise MoveTargetOutOfBoundsException(
-                    "Despite all the workarounds, scrolling to `{}` was unsuccessful.".format(
-                        locator
-                    )
+                    f"Despite all the workarounds, scrolling to `{locator}` was unsuccessful."
                 ) from None
         except ElementNotInteractableException:
             # ChromeDriver 89 started throwing this exception if an element is hidden, because it
@@ -650,25 +632,24 @@ class Browser:
             # https://bugs.chromium.org/p/chromedriver/issues/detail?id=3110
             # https://bugs.chromium.org/p/chromedriver/issues/detail?id=3087
             elif (
-                self.browser_type == "chrome"
-                and 76 <= self.browser_version < 78
-                and ("Cannot read property 'left' of undefined" in e.msg)
-            ):
-                pass
-            # Previous issue ^ wasn't fixed in Chrome 78 but throws another error
-            elif (
-                self.browser_type == "chrome"
-                and self.browser_version >= 78
-                and (
-                    "Failed to execute 'elementsFromPoint' on 'Document': The provided double "
-                    "value is non-finite." in e.msg
+                (
+                    self.browser_type == "chrome"
+                    and 76 <= self.browser_version < 78
+                    and ("Cannot read property 'left' of undefined" in e.msg)
                 )
-            ):
-                pass
-            elif (
-                self.browser_type == "chrome"
-                and self.browser_version >= 123
-                and ("has no size and location" in e.msg)
+                or (
+                    self.browser_type == "chrome"
+                    and self.browser_version >= 78
+                    and (
+                        "Failed to execute 'elementsFromPoint' on 'Document': The provided double "
+                        "value is non-finite." in e.msg
+                    )
+                )
+                or (
+                    self.browser_type == "chrome"
+                    and self.browser_version >= 123
+                    and ("has no size and location" in e.msg)
+                )
             ):
                 pass
             else:
@@ -705,8 +686,8 @@ class Browser:
     def drag_and_drop_to(
         self,
         source: LocatorAlias,
-        to_x: Optional[int] = None,
-        to_y: Optional[int] = None,
+        to_x: int | None = None,
+        to_y: int | None = None,
     ) -> None:
         """Drags an element to a target location specified by ``to_x`` and ``to_y``
 
@@ -751,7 +732,7 @@ class Browser:
         return self.selenium.refresh()
 
     @retry_stale_element
-    def classes(self, locator: LocatorAlias, *args, **kwargs) -> Set[str]:
+    def classes(self, locator: LocatorAlias, *args, **kwargs) -> set[str]:
         """Return a list of classes attached to the element.
 
         Args: See :py:meth:`elements`
@@ -811,7 +792,7 @@ class Browser:
         return result
 
     @retry_stale_element
-    def attributes(self, locator: LocatorAlias, *args, **kwargs) -> Dict:
+    def attributes(self, locator: LocatorAlias, *args, **kwargs) -> dict:
         """Return a dict of attributes attached to the element.
 
         Args: See :py:meth:`elements`
@@ -828,7 +809,7 @@ class Browser:
         return result
 
     @retry_stale_element
-    def get_attribute(self, attr: str, *args, **kwargs) -> Optional[str]:
+    def get_attribute(self, attr: str, *args, **kwargs) -> str | None:
         return self.element(*args, **kwargs).get_attribute(attr)
 
     @retry_stale_element
@@ -975,7 +956,7 @@ class Browser:
         if not self.handles_alerts:
             return False
         try:
-            self.get_alert().text
+            _ = self.get_alert().text
         except NoAlertPresentException:
             return False
         else:
@@ -999,9 +980,9 @@ class Browser:
         cancel: bool = False,
         wait: float = 30.0,
         squash: bool = False,
-        prompt: Optional[str] = None,
+        prompt: str | None = None,
         check_present: bool = False,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         """Handles an alert popup.
 
         Args:
@@ -1059,7 +1040,7 @@ class Browser:
 
     def switch_to_frame(self, *args, **kwargs) -> None:
         parent = kwargs.pop("parent", self.browser)
-        self.selenium.switch_to.frame(self.element(parent=parent, *args, **kwargs))
+        self.selenium.switch_to.frame(self.element(*args, parent=parent, **kwargs))
 
     def switch_to_main_frame(self) -> None:
         self.selenium.switch_to.default_content()
@@ -1076,7 +1057,7 @@ class Browser:
         return window_handle
 
     @property
-    def window_handles(self) -> List[str]:
+    def window_handles(self) -> list[str]:
         """Returns all available window handles"""
         handles = self.selenium.window_handles
         self.logger.debug("window_handles -> %r", handles)
@@ -1109,7 +1090,7 @@ class Browser:
             self.switch_to_window(new_handle)
         return new_handle
 
-    def close_window(self, window_handle: Optional[str] = None) -> None:
+    def close_window(self, window_handle: str | None = None) -> None:
         """Close window form browser
 
         Args:
@@ -1152,11 +1133,11 @@ class BrowserParentWrapper:
            defined.
     """
 
-    def __init__(self, o: "Widget", browser: Browser) -> None:
+    def __init__(self, o: Widget, browser: Browser) -> None:
         self._o = o
         self._browser = browser
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, BrowserParentWrapper):
             return False
         return self._o == other._o and self._browser == other._browser
@@ -1164,11 +1145,11 @@ class BrowserParentWrapper:
     def elements(
         self,
         locator: LocatorAlias,
-        parent: Optional[ElementParent] = None,
+        parent: ElementParent | None = None,
         check_visibility: bool = False,
         check_safe: bool = True,
         force_check_safe: bool = False,
-    ) -> List[WebElement]:
+    ) -> list[WebElement]:
         return self._browser.elements(
             locator,
             parent=parent or self._o,

--- a/src/widgetastic/exceptions.py
+++ b/src/widgetastic/exceptions.py
@@ -1,10 +1,12 @@
-from selenium.common.exceptions import ElementNotInteractableException
-from selenium.common.exceptions import MoveTargetOutOfBoundsException
-from selenium.common.exceptions import NoAlertPresentException
-from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import StaleElementReferenceException
-from selenium.common.exceptions import UnexpectedAlertPresentException
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import (
+    ElementNotInteractableException,
+    MoveTargetOutOfBoundsException,
+    NoAlertPresentException,
+    NoSuchElementException,
+    StaleElementReferenceException,
+    UnexpectedAlertPresentException,
+    WebDriverException,
+)
 
 
 class WidgetasticException(Exception):
@@ -28,15 +30,15 @@ class RowNotFound(IndexError, WidgetasticException):
 
 
 __all__ = [
+    "DoNotReadThisWidget",
     "ElementNotInteractableException",
     "MoveTargetOutOfBoundsException",
     "NoAlertPresentException",
     "NoSuchElementException",
+    "RowNotFound",
     "StaleElementReferenceException",
     "UnexpectedAlertPresentException",
     "WebDriverException",
-    "WidgetasticException",
     "WidgetOperationFailed",
-    "DoNotReadThisWidget",
-    "RowNotFound",
+    "WidgetasticException",
 ]

--- a/src/widgetastic/log.py
+++ b/src/widgetastic/log.py
@@ -1,18 +1,11 @@
+from __future__ import annotations
+
 import functools
 import logging
 import time
-from typing import Any
-from typing import Callable
-from typing import cast
-from typing import Iterator
-from typing import MutableMapping
-from typing import Optional
-from typing import Tuple
-from typing import TypeVar
-from typing import Union
+from typing import Any, Callable, Iterator, MutableMapping, TypeVar, cast
 
 from .exceptions import DoNotReadThisWidget
-
 
 null_logger = logging.getLogger("widgetastic_null")
 null_logger.addHandler(logging.NullHandler())
@@ -42,7 +35,7 @@ class PrependParentsAdapter(logging.LoggerAdapter):
 
     def process(
         self, msg: str, kwargs: MutableMapping[str, Any]
-    ) -> Tuple[str, MutableMapping[str, Any]]:
+    ) -> tuple[str, MutableMapping[str, Any]]:
         assert self.extra is not None  # python 3.10+ type check
         widget_path = cast(str, self.extra["widget_path"])
         # Sanitizing %->%% for formatter working properly
@@ -57,7 +50,7 @@ class PrependParentsAdapter(logging.LoggerAdapter):
 
 
 def create_widget_logger(
-    widget_path: str, logger: Optional[logging.Logger] = None
+    widget_path: str, logger: logging.Logger | None = None
 ) -> PrependParentsAdapter:
     """Create a logger that prepends the ``widget_path`` to the log records.
 
@@ -96,9 +89,7 @@ def create_child_logger(parent_logger: logging.Logger, child_name: str) -> Prepe
     return _create_logger_appender(parent_logger, f"/{child_name}")
 
 
-def create_item_logger(
-    parent_logger: logging.Logger, item: Union[str, int]
-) -> PrependParentsAdapter:
+def create_item_logger(parent_logger: logging.Logger, item: str | int) -> PrependParentsAdapter:
     """Creates a logger for a widget that is inside iteration - referred to by index or key.
 
     Args:
@@ -143,14 +134,14 @@ def logged(log_args: bool = False, log_result: bool = False) -> Callable[[F], F]
                     elapsed_time,
                 )
                 raise
-            except Exception as e:
+            except Exception:
                 elapsed_time = (time.time() - start_time) * 1000.0
                 self.logger.error(
                     "An exception happened during %s call (elapsed %.0f ms)",
                     signature,
                     elapsed_time,
                 )
-                self.logger.exception(e)
+                self.logger.exception("Exception details")
                 raise
             else:
                 elapsed_time = (time.time() - start_time) * 1000.0

--- a/src/widgetastic/ouia/__init__.py
+++ b/src/widgetastic/ouia/__init__.py
@@ -1,12 +1,11 @@
+from __future__ import annotations
+
 from logging import Logger
-from typing import Optional
 
 from widgetastic.browser import Browser
 from widgetastic.types import ViewParent
 from widgetastic.utils import ParametrizedLocator
-from widgetastic.widget.base import ClickableMixin
-from widgetastic.widget.base import View
-from widgetastic.widget.base import Widget
+from widgetastic.widget.base import ClickableMixin, View, Widget
 from widgetastic.xpath import quote
 
 
@@ -67,16 +66,16 @@ class OUIAGenericView(OUIABase, View):
     """
 
     OUIA_COMPONENT_TYPE: str
-    OUIA_ID: Optional[str]
+    OUIA_ID: str | None
 
     def __init__(
         self,
         parent: ViewParent,
         component_id: str = "",
-        logger: Optional[Logger] = None,
+        logger: Logger | None = None,
         **kwargs,
     ) -> None:
-        component_type: Optional[str] = kwargs.pop("component_type", None)
+        component_type: str | None = kwargs.pop("component_type", None)
         self._set_attrs(
             component_type=component_type or self.OUIA_COMPONENT_TYPE or type(self).__name__,
             component_id=getattr(self, "OUIA_ID", component_id),
@@ -105,8 +104,8 @@ class OUIAGenericWidget(OUIABase, Widget, ClickableMixin):
         self,
         parent: ViewParent,
         component_id: str = "",
-        logger: Optional[Logger] = None,
-        component_type: Optional[str] = None,
+        logger: Logger | None = None,
+        component_type: str | None = None,
     ) -> None:
         self._set_attrs(
             component_type=component_type or self.OUIA_COMPONENT_TYPE or type(self).__name__,

--- a/src/widgetastic/types.py
+++ b/src/widgetastic/types.py
@@ -1,27 +1,20 @@
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Protocol
-from typing import Tuple
-from typing import TYPE_CHECKING
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Dict, List, Protocol, Tuple, Union
 
 from selenium.webdriver.remote.webelement import WebElement
 from smartloc import Locator
 
-
 if TYPE_CHECKING:
     from .browser import Browser
     from .utils import Version
-    from .widget.base import View
-    from .widget.base import Widget
-    from .widget.base import ClickableMixin
+    from .widget.base import ClickableMixin, View, Widget
 
 
 class LocatorProtocol(Protocol):
     CHECK_VISIBILITY: bool
 
-    def __locator__(self) -> Union[str, Locator, WebElement]: ...
+    def __locator__(self) -> str | Locator | WebElement: ...
 
 
 LocatorAlias = Union[str, Dict[str, str], WebElement, LocatorProtocol, "Widget"]

--- a/src/widgetastic/utils.py
+++ b/src/widgetastic/utils.py
@@ -1,17 +1,19 @@
 """This module contains some supporting classes."""
 
+from __future__ import annotations
+
 import functools
 import re
 import string
 import time
 from threading import Lock
+from typing import Callable, ClassVar
 
 from cached_property import cached_property
 from selenium.common.exceptions import StaleElementReferenceException
 from smartloc import Locator
 
-from . import log
-from . import xpath
+from . import log, xpath
 
 
 class Widgetable:
@@ -137,18 +139,16 @@ class Version:
         return self.vstring
 
     def __repr__(self):
-        return f"{type(self).__name__}({repr(self.vstring)})"
+        return f"{type(self).__name__}({self.vstring!r})"
 
     def __lt__(self, other):
         try:
             if not isinstance(other, Version):
                 other = Version(other)
-        except Exception:
-            raise ValueError(f"Cannot compare Version to {type(other).__name__}")
+        except (TypeError, ValueError, AttributeError):
+            raise ValueError(f"Cannot compare Version to {type(other).__name__}") from None
 
-        if self == other:
-            return False
-        elif self == self.latest() or other == self.lowest():
+        if self == other or self == self.latest() or other == self.lowest():
             return False
         elif self == self.lowest() or other == self.latest():
             return True
@@ -186,7 +186,7 @@ class Version:
             return (
                 self.version == other.version and self.normalized_suffix == other.normalized_suffix
             )
-        except Exception:
+        except (TypeError, ValueError, AttributeError):
             return False
 
     def __contains__(self, ver):
@@ -201,7 +201,7 @@ class Version:
         """
         try:
             return Version(ver).is_in_series(self)
-        except Exception:
+        except (TypeError, ValueError, AttributeError):
             return False
 
     def is_in_series(self, series):
@@ -217,10 +217,7 @@ class Version:
         if not isinstance(series, Version):
             series = Version(series)
         if self in {self.lowest(), self.latest()}:
-            if series == self:
-                return True
-            else:
-                return False
+            return series == self
         return series.version == self.version[: len(series.version)]
 
     def series(self, n=2):
@@ -279,7 +276,7 @@ class VersionPick(Widgetable, ConstructorResolvable):
         self.version_dict = version_dict
 
     def __repr__(self):
-        return f"{type(self).__name__}({repr(self.version_dict)})"
+        return f"{type(self).__name__}({self.version_dict!r})"
 
     @property
     def child_items(self):
@@ -304,9 +301,7 @@ class VersionPick(Widgetable, ConstructorResolvable):
             return v_dict.get(sorted_matching_versions[0])
         else:
             raise ValueError(
-                "When trying to version pick {!r} in {!r}, matching version was not found".format(
-                    version, versions
-                )
+                f"When trying to version pick {version!r} in {versions!r}, matching version was not found"
             )
 
     def __get__(self, o, type=None):
@@ -389,7 +384,7 @@ class ParametrizedString(ConstructorResolvable):
         template: String template in ``.format()`` format,
     """
 
-    OPERATIONS = {
+    OPERATIONS: ClassVar[dict[str, Callable[[str], str]]] = {
         "quote": xpath.quote,
         "lower": lambda s: s.lower(),
         "upper": lambda s: s.upper(),
@@ -537,9 +532,7 @@ def nested_getattr(o, steps):
         steps = steps.split(".")
     if not isinstance(steps, (list, tuple)):
         raise TypeError(
-            "nested_getattr only accepts strings, lists, or tuples!, You passed {}".format(
-                type(steps).__name__
-            )
+            f"nested_getattr only accepts strings, lists, or tuples!, You passed {type(steps).__name__}"
         )
     steps = [step.strip() for step in steps if step.strip()]
     if not steps:
@@ -611,7 +604,7 @@ def crop_string_middle(s, length=32, cropper="..."):
     return s[:half] + cropper + s[-half - 1 :]
 
 
-class partial_match:  # noqa
+class partial_match:
     """Use this to wrap values to be selected using partial matching in various objects.
 
     It proxies all ``get`` operations to the underlying ``item``.
@@ -693,8 +686,7 @@ def retry_stale_element(method):
                 return method(*args, **kwargs)
             except StaleElementReferenceException:
                 time.sleep(0.5)
-        else:
-            raise StaleElementReferenceException("Couldn't handle it")
+        raise StaleElementReferenceException("Couldn't handle it")
 
     return wrap
 

--- a/src/widgetastic/widget/__init__.py
+++ b/src/widgetastic/widget/__init__.py
@@ -1,28 +1,23 @@
 """This module contains the base classes that are used to implement the more specific behaviour."""
 
-from .base import *  # noqa: F403 F401
+from .base import *
 from .checkbox import Checkbox
 from .image import Image
-from .input import BaseInput
-from .input import ColourInput
-from .input import FileInput
-from .input import TextInput
+from .input import BaseInput, ColourInput, FileInput, TextInput
 from .select import Select
-from .table import Table
-from .table import TableColumn
-from .table import TableRow
+from .table import Table, TableColumn, TableRow
 from .text import Text
 
 __all__ = [
-    "Image",
     "BaseInput",
     "Checkbox",
     "ColourInput",
     "FileInput",
-    "TextInput",
+    "Image",
     "Select",
     "Table",
     "TableColumn",
     "TableRow",
     "Text",
+    "TextInput",
 ]

--- a/src/widgetastic/widget/base.py
+++ b/src/widgetastic/widget/base.py
@@ -8,24 +8,26 @@ from selenium.webdriver.remote.webelement import WebElement
 from smartloc import Locator
 from wait_for import wait_for
 
-from widgetastic.browser import Browser
-from widgetastic.browser import BrowserParentWrapper
-from widgetastic.exceptions import DoNotReadThisWidget
-from widgetastic.exceptions import LocatorNotImplemented
-from widgetastic.log import call_sig
-from widgetastic.log import create_child_logger
-from widgetastic.log import create_widget_logger
-from widgetastic.log import logged
-from widgetastic.log import PrependParentsAdapter
-from widgetastic.utils import ConstructorResolvable
-from widgetastic.utils import DefaultFillViewStrategy
-from widgetastic.utils import deflatten_dict
-from widgetastic.utils import Fillable
-from widgetastic.utils import FillContext
-from widgetastic.utils import nested_getattr
-from widgetastic.utils import ParametrizedLocator
-from widgetastic.utils import ParametrizedString
-from widgetastic.utils import Widgetable
+from widgetastic.browser import Browser, BrowserParentWrapper
+from widgetastic.exceptions import DoNotReadThisWidget, LocatorNotImplemented
+from widgetastic.log import (
+    PrependParentsAdapter,
+    call_sig,
+    create_child_logger,
+    create_widget_logger,
+    logged,
+)
+from widgetastic.utils import (
+    ConstructorResolvable,
+    DefaultFillViewStrategy,
+    Fillable,
+    FillContext,
+    ParametrizedLocator,
+    ParametrizedString,
+    Widgetable,
+    deflatten_dict,
+    nested_getattr,
+)
 
 
 def do_not_read_this_widget():
@@ -411,10 +413,11 @@ class Widget(metaclass=WidgetMetaclass):
         result = []
         for key in dir(cls):
             value = getattr(cls, key)
-            if isinstance(value, Widgetable):
-                # check the values of a VersionPick object are widgetable themselves
-                if all([isinstance(item, Widgetable) for item in value.child_items]):
-                    result.append((key, value))
+            # check the values of a VersionPick object are widgetable themselves
+            if isinstance(value, Widgetable) and all(
+                isinstance(item, Widgetable) for item in value.child_items
+            ):
+                result.append((key, value))
         for includer in cls._included_widgets:
             result.append((None, includer))
         presorted_widgets = sorted(result, key=lambda pair: pair[1]._seq_id)
@@ -449,8 +452,7 @@ class Widget(metaclass=WidgetMetaclass):
         for locatable in list(reversed(self.hierarchy))[1:]:
             if hasattr(locatable, "__locator__") and not getattr(locatable, "INDIRECT", False):
                 return locatable
-        else:
-            return None
+        return None
 
     @property
     def root_browser(self):
@@ -550,7 +552,6 @@ class Widget(metaclass=WidgetMetaclass):
         Args:
             widget: The widget being accessed or :py:class:`ParametrizedViewRequest`.
         """
-        pass
 
     def fill(self, *args, **kwargs):
         """Interactive objects like inputs, selects, checkboxes, et cetera should implement fill.
@@ -666,14 +667,14 @@ class Widget(metaclass=WidgetMetaclass):
 
 
 def _gen_locator_meth(loc):
-    def __locator__(self):  # noqa
+    def __locator__(self):
         return loc
 
     return __locator__
 
 
 def _gen_locator_root():
-    def __locator__(self):  # noqa
+    def __locator__(self):
         return self.ROOT
 
     return __locator__
@@ -805,9 +806,7 @@ class ConditionalSwitchableView(Widgetable):
                 or (inspect.isclass(cls_or_descriptor) and issubclass(cls_or_descriptor, Widget))
             ):
                 raise TypeError(
-                    "Unsupported object registered into the selector ({!r})".format(
-                        cls_or_descriptor
-                    )
+                    f"Unsupported object registered into the selector ({cls_or_descriptor!r})"
                 )
             self.registered_views.append((condition, cls_or_descriptor))
             if default:
@@ -815,7 +814,6 @@ class ConditionalSwitchableView(Widgetable):
                     raise TypeError("Multiple default views specified")
                 self.default_view = cls_or_descriptor
             # We explicitly return None
-            return None
 
         if widget is None:
             return view_process
@@ -846,9 +844,7 @@ class ConditionalSwitchableView(Widgetable):
                             condition_arg_cache[self.reference] = ref_value
                         except AttributeError:
                             raise TypeError(
-                                "Wrong widget name specified as reference=: {}".format(
-                                    self.reference
-                                )
+                                f"Wrong widget name specified as reference=: {self.reference}"
                             )
                         except NoSuchElementException:
                             if self.ignore_bad_reference:
@@ -1054,7 +1050,6 @@ class View(Widget):
         Args:
             values: The same values that are passed to :py:meth:`fill`
         """
-        pass
 
     def after_fill(self, was_change):
         """A hook invoked after all the widgets were filled.
@@ -1065,7 +1060,6 @@ class View(Widget):
         Args:
             was_change: :py:class:`bool` signalizing whether the :py:meth:`fill` changed anything,
         """
-        pass
 
     def child_widget_accessed(self, widget):
         """This hook is called when a child widget of current view is accessed.
@@ -1078,7 +1072,7 @@ class View(Widget):
         self.browser.switch_to_main_frame()
         parents = [p for p in self.hierarchy if getattr(p, "FRAME", None)]
         for parent in parents:
-            self.browser.switch_to_frame(getattr(parent, "FRAME"))
+            self.browser.switch_to_frame(parent.FRAME)
 
 
 class ParametrizedView(View):
@@ -1186,9 +1180,7 @@ class ParametrizedViewRequest:
         for param in self.view_class.PARAMETERS:
             if param not in param_dict:
                 raise TypeError(
-                    "You did not pass the required parameter {} into {}".format(
-                        param, self.view_class.__name__
-                    )
+                    f"You did not pass the required parameter {param} into {self.view_class.__name__}"
                 )
 
         new_kwargs = copy(self.kwargs)
@@ -1234,8 +1226,8 @@ class ParametrizedViewRequest:
 
     def __getattr__(self, attr):
         raise AttributeError(
-            "This is not an instance of {}. You need to call this object and pass the required "
-            "parameters of the view.".format(self.view_class.__name__)
+            f"This is not an instance of {self.view_class.__name__}. You need to call this object and pass the required "
+            "parameters of the view."
         )
 
     def read(self):
@@ -1254,7 +1246,7 @@ class ParametrizedViewRequest:
     def fill(self, value):
         was_change = False
         if not isinstance(value, dict):
-            raise ValueError("When filling parametrized view a dict is required")
+            raise TypeError("When filling parametrized view a dict is required")
         for param_tuple, fill_value in value.items():
             if not isinstance(param_tuple, tuple):
                 param_tuple = (param_tuple,)

--- a/src/widgetastic/widget/checkbox.py
+++ b/src/widgetastic/widget/checkbox.py
@@ -1,6 +1,7 @@
+from widgetastic.exceptions import WidgetOperationFailed
+
 from .base import ClickableMixin
 from .input import BaseInput
-from widgetastic.exceptions import WidgetOperationFailed
 
 
 class Checkbox(BaseInput, ClickableMixin):

--- a/src/widgetastic/widget/input.py
+++ b/src/widgetastic/widget/input.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-from .base import Widget
 from widgetastic.exceptions import DoNotReadThisWidget
 from widgetastic.xpath import quote
+
+from .base import Widget
 
 
 class BaseInput(Widget):

--- a/src/widgetastic/widget/select.py
+++ b/src/widgetastic/widget/select.py
@@ -3,9 +3,10 @@ from html import unescape
 
 from cached_property import cached_property
 
-from .base import Widget
 from widgetastic.utils import normalize_space
 from widgetastic.xpath import quote
+
+from .base import Widget
 
 
 class Select(Widget):
@@ -223,9 +224,7 @@ class Select(Widget):
             if not matched:
                 available = ", ".join(repr(opt.text) for opt in self.all_options)
                 raise ValueError(
-                    "Cannot locate option with visible text: {!r}. Available options: {}".format(
-                        text, available
-                    )
+                    f"Cannot locate option with visible text: {text!r}. Available options: {available}"
                 )
 
     def read(self):
@@ -256,10 +255,12 @@ class Select(Widget):
                 try:
                     mod, value = item
                     if not isinstance(mod, str):
-                        raise ValueError("The select modifier must be a string")
+                        raise TypeError("The select modifier must be a string")
                     mod = mod.lower()
-                except ValueError:
-                    raise ValueError("If passing tuples into the S.fill(), they must be 2-tuples")
+                except (ValueError, TypeError):
+                    raise ValueError(
+                        "If passing tuples into the S.fill(), they must be 2-tuples"
+                    ) from None
             else:
                 mod = "by_text"
                 value = item

--- a/src/widgetastic/widget/table.py
+++ b/src/widgetastic/widget/table.py
@@ -1,32 +1,24 @@
 """This module contains the base classes that are used to implement the more specific behaviour."""
 
+from __future__ import annotations
+
 import itertools
 import re
-from collections import defaultdict
-from collections import deque
+from collections import defaultdict, deque
 from copy import copy
 from operator import attrgetter
+from typing import ClassVar
 
-from anytree import AsciiStyle
-from anytree import ChildResolverError
-from anytree import Node
-from anytree import RenderTree
-from anytree import Resolver
-from anytree import ResolverError
+from anytree import AsciiStyle, ChildResolverError, Node, RenderTree, Resolver, ResolverError
 from cached_property import cached_property
 
-from .base import ClickableMixin
-from .base import Widget
-from .base import Widgetable
-from .base import WidgetDescriptor
 from widgetastic.browser import Browser
 from widgetastic.exceptions import RowNotFound
-from widgetastic.log import create_child_logger
-from widgetastic.log import create_item_logger
-from widgetastic.utils import attributize_string
-from widgetastic.utils import ConstructorResolvable
-from widgetastic.utils import ParametrizedLocator
+from widgetastic.log import create_child_logger, create_item_logger
+from widgetastic.utils import ConstructorResolvable, ParametrizedLocator, attributize_string
 from widgetastic.xpath import quote
+
+from .base import ClickableMixin, Widget, Widgetable, WidgetDescriptor
 
 # Python 3.7 formalised the RE pattern type, so let's use that if we can
 try:
@@ -148,10 +140,8 @@ class TableColumn(Widget, ClickableMixin):
                 return False
             else:
                 raise TypeError(
-                    (
-                        "Cannot fill column {}, no widget and the value differs "
-                        "(wanted to fill {!r} but there is {!r}"
-                    ).format(self.column_name or self.position, value, self.text)
+                    f"Cannot fill column {self.column_name or self.position}, no widget and the value differs "
+                    f"(wanted to fill {value!r} but there is {self.text!r}"
                 )
 
 
@@ -216,16 +206,12 @@ class TableRow(Widget, ClickableMixin):
             # We could find either a TableColumn or a TableReference node at this position...
             cols = self.table.resolver.glob(
                 self.table.table_tree,
-                "{}[{}]{}[{}]".format(
-                    self.table.ROW_RESOLVER_PATH, self.index, self.table.COLUMN_RESOLVER_PATH, index
-                ),
+                f"{self.table.ROW_RESOLVER_PATH}[{self.index}]{self.table.COLUMN_RESOLVER_PATH}[{index}]",
                 handle_resolver_error=True,
             )
             if not cols:
                 raise IndexError(
-                    "Row {} has no TableColumn or TableReference node at position {}".format(
-                        repr(self), index
-                    )
+                    f"Row {self!r} has no TableColumn or TableReference node at position {index}"
                 )
             return cols[0].obj
 
@@ -272,18 +258,21 @@ class TableRow(Widget, ClickableMixin):
             value = {self.table.assoc_column_position: value}
 
         changed = False
-        for key, value in value.items():
-            if value is None:
+        for key, item_value in value.items():
+            if item_value is None:
                 self.logger.info("Skipping fill of %r because the value is None", key)
                 continue
             else:
                 self.logger.info("Filling column %r", key)
 
             # if the row widgets aren't visible the row needs to be clicked to edit
-            if hasattr(self.parent, "action_row") and getattr(self[key], "widget", False):
-                if not self[key].widget.is_displayed:
-                    self.click()
-            if self[key].fill(value):
+            if (
+                hasattr(self.parent, "action_row")
+                and getattr(self[key], "widget", False)
+                and not self[key].widget.is_displayed
+            ):
+                self.click()
+            if self[key].fill(item_value):
                 changed = True
         return changed
 
@@ -398,7 +387,7 @@ class Table(Widget):
 
     # These tags are not added as Node objects to the table tree when
     # _process_table is called.
-    IGNORE_TAGS = ["caption", "thead", "tfoot", "colgroup"]
+    IGNORE_TAGS: ClassVar[list[str]] = ["caption", "thead", "tfoot", "colgroup"]
 
     ROW_TAG = "tr"
     COLUMN_TAG = "td"
@@ -409,7 +398,7 @@ class Table(Widget):
 
     Row = TableRow
 
-    _CACHED_PROPERTIES = [
+    _CACHED_PROPERTIES: ClassVar[list[str]] = [
         "headers",
         "attributized_headers",
         "header_index_mapping",
@@ -471,15 +460,8 @@ class Table(Widget):
 
     def __repr__(self):
         return (
-            "{}({!r}, column_widgets={!r}, assoc_column={!r}, rows_ignore_top={!r}, "
-            "rows_ignore_bottom={!r})"
-        ).format(
-            type(self).__name__,
-            self.locator,
-            self.column_widgets,
-            self.assoc_column,
-            self.rows_ignore_top,
-            self.rows_ignore_bottom,
+            f"{type(self).__name__}({self.locator!r}, column_widgets={self.column_widgets!r}, assoc_column={self.assoc_column!r}, rows_ignore_top={self.rows_ignore_top!r}, "
+            f"rows_ignore_bottom={self.rows_ignore_bottom!r})"
         )
 
     def _process_negative_index(self, nindex):
@@ -578,18 +560,14 @@ class Table(Widget):
                 row = self.row((self.assoc_column, item))
             except RowNotFound:
                 raise KeyError(
-                    "Row {!r} not found in table by associative column {!r}".format(
-                        item, self.assoc_column
-                    )
+                    f"Row {item!r} not found in table by associative column {self.assoc_column!r}"
                 )
             at_index = row.index
         elif isinstance(item, int):
             at_index = item
             if at_index >= self.row_count:
                 raise IndexError(
-                    "Integer row index {} is greater than max index {}".format(
-                        at_index, self.row_count - 1
-                    )
+                    f"Integer row index {at_index} is greater than max index {self.row_count - 1}"
                 )
         else:
             raise TypeError("Table [] accepts only strings or integers.")
@@ -731,9 +709,7 @@ class Table(Widget):
                     q = f"contains(normalize-space(.), normalize-space({quote(value)}))"
                 elif method == "startswith":
                     # starts with
-                    q = ("starts-with(normalize-space(.), normalize-space({}))").format(
-                        quote(value)
-                    )
+                    q = f"starts-with(normalize-space(.), normalize-space({quote(value)}))"
                 elif method == "endswith":
                     # ends with
                     # This needs to be faked since selenium does not support this feature.
@@ -941,8 +917,7 @@ class Table(Widget):
                 # But the value didn't match, keep looping
                 else:
                     continue
-            else:
-                raise RowNotFound(f"Row not found by {column!r}/{value!r}")
+            raise RowNotFound(f"Row not found by {column!r}/{value!r}")
 
     def read(self):
         """Reads the table. Returns a list, every item in the list is contents read from the row."""
@@ -968,9 +943,7 @@ class Table(Widget):
                             key = row_read.pop(self.assoc_column)
                         except KeyError:
                             raise ValueError(
-                                "The assoc_column={!r} could not be retrieved".format(
-                                    self.assoc_column
-                                )
+                                f"The assoc_column={self.assoc_column!r} could not be retrieved"
                             )
                 if key in result:
                     raise ValueError(f"Duplicate value for {key}={result[key]!r}")
@@ -1218,17 +1191,14 @@ class TableResolver(Resolver):
         matching_nodes = self._Resolver__find(node, part, None)
         for node_at_pos in filter(lambda n: n.position == int(position), matching_nodes):
             return node_at_pos
-        else:
-            names = [
-                f"{repr(getattr(c, self.pathattr, None))}[{c.position}]" for c in node.children
-            ]
-            raise ResolverError(
-                node,
-                part,
-                "{} has no child '{}' with position={}. Children are: {}".format(
-                    repr(node), part, position, ", ".join(names)
-                ),
-            )
+        names = [f"{getattr(c, self.pathattr, None)!r}[{c.position}]" for c in node.children]
+        raise ResolverError(
+            node,
+            part,
+            "{} has no child '{}' with position={}. Children are: {}".format(
+                repr(node), part, position, ", ".join(names)
+            ),
+        )
 
     def __find(self, node, pat, remainder):
         matches = []
@@ -1240,7 +1210,7 @@ class TableResolver(Resolver):
                         matches += self.__glob(child, remainder)
                     else:
                         matches.append(child)
-            except ResolverError as exc:
+            except ResolverError:
                 if not self.is_wildcard(pat):
-                    raise exc
+                    raise
         return matches

--- a/src/widgetastic/xpath.py
+++ b/src/widgetastic/xpath.py
@@ -1,6 +1,5 @@
 import re
-from xml.sax.saxutils import quoteattr
-from xml.sax.saxutils import unescape
+from xml.sax.saxutils import quoteattr, unescape
 
 
 def quote(s):

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -8,7 +8,6 @@ from wait_for import wait_for
 
 from widgetastic.browser import Browser
 
-
 OPTIONS = {"firefox": webdriver.FirefoxOptions(), "chrome": webdriver.ChromeOptions()}
 
 

--- a/testing/ouia_widgets.py
+++ b/testing/ouia_widgets.py
@@ -1,5 +1,4 @@
-from widgetastic.ouia import OUIAGenericView
-from widgetastic.ouia import OUIAGenericWidget
+from widgetastic.ouia import OUIAGenericView, OUIAGenericWidget
 
 
 class Button(OUIAGenericWidget):

--- a/testing/test_basic_widgets.py
+++ b/testing/test_basic_widgets.py
@@ -3,18 +3,17 @@ import re
 import pytest
 
 from widgetastic.exceptions import DoNotReadThisWidget
-from widgetastic.utils import Fillable
-from widgetastic.utils import ParametrizedString
-from widgetastic.utils import Version
-from widgetastic.utils import VersionPick
-from widgetastic.widget import Checkbox
-from widgetastic.widget import ColourInput
-from widgetastic.widget import FileInput
-from widgetastic.widget import Select
-from widgetastic.widget import Table
-from widgetastic.widget import Text
-from widgetastic.widget import TextInput
-from widgetastic.widget import View
+from widgetastic.utils import Fillable, ParametrizedString, Version, VersionPick
+from widgetastic.widget import (
+    Checkbox,
+    ColourInput,
+    FileInput,
+    Select,
+    Table,
+    Text,
+    TextInput,
+    View,
+)
 from widgetastic.widget.table import TableRow
 
 
@@ -344,7 +343,7 @@ def test_table(browser):
     assert view.table1[1].last_name.text == "Thornton"
 
     with pytest.raises(AttributeError):
-        row.papalala
+        _ = row.papalala
 
     with pytest.raises(TypeError):
         view.table["boom!"]
@@ -522,7 +521,7 @@ def test_table_multiple_tbody(browser):
     assert view.table1[1].last_name.text == "Thornton"
 
     with pytest.raises(AttributeError):
-        row.papalala
+        _ = row.papalala
 
     with pytest.raises(TypeError):
         view.table1["boom!"]
@@ -977,7 +976,7 @@ def test_parametrized_locator(browser):
     # This uses value defined on class so it should work
     assert good.header_cls.text == "test test"
     with pytest.raises(AttributeError):
-        bad.header.text
+        _ = bad.header.text
 
     with pytest.raises(AttributeError):
         bad.input.read()

--- a/testing/test_browser.py
+++ b/testing/test_browser.py
@@ -1,15 +1,12 @@
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from widgetastic.browser import BrowserParentWrapper
-from widgetastic.browser import WebElement
-from widgetastic.exceptions import LocatorNotImplemented
-from widgetastic.exceptions import NoSuchElementException
-from widgetastic.widget import Text
-from widgetastic.widget import View
+from widgetastic.browser import BrowserParentWrapper, WebElement
+from widgetastic.exceptions import LocatorNotImplemented, NoSuchElementException
+from widgetastic.widget import Text, View
 
 
 @pytest.fixture()
@@ -104,9 +101,12 @@ def test_wait_for_element_visible(browser):
 def test_wait_for_element_exception_control(browser, exception):
     # Click on the button, element will not appear
     browser.click("#invisible_appear_button")
-    wait_for_args = dict(
-        locator="#invisible_appear_p", visible=True, timeout=1.5, exception=exception
-    )
+    wait_for_args = {
+        "locator": "#invisible_appear_p",
+        "visible": True,
+        "timeout": 1.5,
+        "exception": exception,
+    }
     if exception:
         with pytest.raises(NoSuchElementException):
             browser.wait_for_element(**wait_for_args)
@@ -201,24 +201,24 @@ def test_nested_views_parent_injection(browser):
     class MyView(View):
         ROOT = "#proper"
 
-        class c1(View):  # noqa
+        class c1(View):
             ROOT = ".c1"
 
             w = Text(".lookmeup")
 
-        class c2(View):  # noqa
+        class c2(View):
             ROOT = ".c2"
 
             w = Text(".lookmeup")
 
-        class c3(View):  # noqa
+        class c3(View):
             ROOT = ".c3"
 
             w = Text(".lookmeup")
 
-        class without(View):  # noqa
+        class without(View):
             # This one receives the parent browser wrapper
-            class nested(View):  # noqa
+            class nested(View):
                 # and it should work in multiple levels
                 pass
 
@@ -311,7 +311,7 @@ def test_window_handles(browser, current_and_new_handle):
 
 def test_close_window(browser, current_and_new_handle):
     """Test close window"""
-    main_handle, new_handle = current_and_new_handle
+    _main_handle, new_handle = current_and_new_handle
 
     assert new_handle in browser.window_handles
     browser.close_window(new_handle)
@@ -369,7 +369,7 @@ def test_handle_alert(browser, cancel_text, prompt, invoke_alert):
 def test_save_screenshot(browser):
     """Test browser save screenshot method."""
     tmp_dir = tempfile._get_default_tempdir()
-    filename = Path(tmp_dir) / f"{datetime.now()}.png"
+    filename = Path(tmp_dir) / f"{datetime.now(tz=timezone.utc)}.png"
     assert not filename.exists()
     browser.save_screenshot(filename=filename.as_posix())
     assert filename.exists()

--- a/testing/test_log.py
+++ b/testing/test_log.py
@@ -1,9 +1,7 @@
 import pytest
 
-from widgetastic.log import call_sig
-from widgetastic.log import call_unlogged
-from widgetastic.widget import Text
-from widgetastic.widget import View
+from widgetastic.log import call_sig, call_unlogged
+from widgetastic.widget import Text, View
 
 
 def test_override(browser):

--- a/testing/test_ouia.py
+++ b/testing/test_ouia.py
@@ -1,6 +1,5 @@
 import pytest
-from ouia_widgets import Button
-from ouia_widgets import Select
+from ouia_widgets import Button, Select
 
 from widgetastic.ouia import OUIAGenericView
 from widgetastic.ouia.checkbox import Checkbox

--- a/testing/test_table.py
+++ b/testing/test_table.py
@@ -1,7 +1,6 @@
 from cached_property import cached_property
 
-from widgetastic.widget import Table
-from widgetastic.widget import View
+from widgetastic.widget import Table, View
 
 
 def test_table_cached_properties():

--- a/testing/test_utils.py
+++ b/testing/test_utils.py
@@ -1,9 +1,6 @@
 import pytest
 
-from widgetastic.utils import nested_getattr
-from widgetastic.utils import ParametrizedLocator
-from widgetastic.utils import ParametrizedString
-from widgetastic.utils import partial_match
+from widgetastic.utils import ParametrizedLocator, ParametrizedString, nested_getattr, partial_match
 from widgetastic.widget import View
 
 
@@ -27,8 +24,8 @@ def test_nested_getattr_single_level():
 
 def test_nested_getattr_multi_level():
     class Obj:
-        class foo:  # noqa
-            class bar:  # noqa
+        class foo:
+            class bar:
                 lol = "heh"
 
     assert nested_getattr(Obj, "foo.bar.lol") == "heh"
@@ -60,10 +57,10 @@ def test_parametrized_string_param_locator(browser):
 
 def test_parametrized_string_nested(browser):
     class MyView(View):
-        class child_item:  # noqa
+        class child_item:
             foo = "bar"
 
-        class owner(View):  # noqa
+        class owner(View):
             p_str1 = ParametrizedString("{@parent/child_item/foo}")
 
     view = MyView(browser)

--- a/testing/test_version_pick.py
+++ b/testing/test_version_pick.py
@@ -1,12 +1,7 @@
 import pytest
 
-from widgetastic.utils import Version
-from widgetastic.utils import VersionPick
-from widgetastic.widget import Checkbox
-from widgetastic.widget import Select
-from widgetastic.widget import Table
-from widgetastic.widget import TextInput
-from widgetastic.widget import View
+from widgetastic.utils import Version, VersionPick
+from widgetastic.widget import Checkbox, Select, Table, TextInput, View
 
 
 def test_empty_verpick_fails():
@@ -31,7 +26,7 @@ def basic_verpick():
 @pytest.fixture(scope="function")
 def descriptor_verpick():
     class MyClass:
-        class browser:  # NOQA
+        class browser:
             product_version = None
 
         verpicked = VersionPick(

--- a/testing/test_view.py
+++ b/testing/test_view.py
@@ -1,23 +1,22 @@
 import pytest
 
 from widgetastic.exceptions import NoSuchElementException
-from widgetastic.utils import Ignore
-from widgetastic.utils import Parameter
-from widgetastic.utils import ParametrizedLocator
-from widgetastic.utils import ParametrizedString
-from widgetastic.widget import Checkbox
-from widgetastic.widget import ConditionalSwitchableView
-from widgetastic.widget import do_not_read_this_widget
-from widgetastic.widget import FileInput
-from widgetastic.widget import ParametrizedView
-from widgetastic.widget import ParametrizedViewRequest
-from widgetastic.widget import Select
-from widgetastic.widget import Text
-from widgetastic.widget import TextInput
-from widgetastic.widget import View
-from widgetastic.widget import Widget
-from widgetastic.widget import WidgetDescriptor
-from widgetastic.widget import WTMixin
+from widgetastic.utils import Ignore, Parameter, ParametrizedLocator, ParametrizedString
+from widgetastic.widget import (
+    Checkbox,
+    ConditionalSwitchableView,
+    FileInput,
+    ParametrizedView,
+    ParametrizedViewRequest,
+    Select,
+    Text,
+    TextInput,
+    View,
+    Widget,
+    WidgetDescriptor,
+    WTMixin,
+    do_not_read_this_widget,
+)
 
 
 def test_can_create_view(browser):
@@ -162,7 +161,7 @@ def test_mixin_view(browser):
 
     view = AView2(browser)
     assert view.widget_names == ("a_mixin_widget", "widget1", "widget2")
-    view.a_mixin_widget
+    _ = view.a_mixin_widget
 
 
 def test_do_not_read_widget(browser):
@@ -190,7 +189,7 @@ def test_view_parameter(browser):
     assert MyView(browser, additional_context={"foo": "bar"}).my_param == "bar"
 
     with pytest.raises(AttributeError):
-        MyView(browser).my_param
+        _ = MyView(browser).my_param
 
 
 def test_view_parametrized_string(browser):
@@ -351,8 +350,8 @@ def test_cache(browser):
     assert len(view.nested1.nested2._widget_cache.keys()) == 0
     assert len(view.nested1.nested2.nested3._widget_cache.keys()) == 0
 
-    view.w
-    assert set(view._widget_cache.keys()) == {getattr(MyView, "w"), getattr(MyView, "nested1")}
+    _ = view.w
+    assert set(view._widget_cache.keys()) == {MyView.w, MyView.nested1}
     view.flush_widget_cache()
     assert len(view._widget_cache.keys()) == 0
 
@@ -484,15 +483,15 @@ def test_switchable_view_with_bad_reference_negative(browser):
     view = MyView(browser)
 
     with pytest.raises(NoSuchElementException):
-        view.the_switchable_view.widget.read()
+        _ = view.the_switchable_view.widget.read()
 
 
 def test_switchable_view_with_nested_reference(browser):
     class MyView(View):
         the_reference = Select(id="switchabletesting-select")
 
-        class nest1(View):  # noqa
-            class nest2(View):  # noqa
+        class nest1(View):
+            class nest2(View):
                 the_switchable_view = ConditionalSwitchableView(
                     reference="parent.parent.the_reference"
                 )
@@ -635,7 +634,7 @@ def test_switchable_view_string_without_reference(browser):
 
     view = MyView(browser)
     with pytest.raises(TypeError):
-        view.the_switchable_view
+        _ = view.the_switchable_view
 
 
 def test_switchable_view_string_bad_reference(browser):
@@ -650,7 +649,7 @@ def test_switchable_view_string_bad_reference(browser):
 
     view = MyView(browser)
     with pytest.raises(TypeError):
-        view.the_switchable_view
+        _ = view.the_switchable_view
 
 
 def test_switchable_view_string_nonsimple_lambda(browser):
@@ -665,7 +664,7 @@ def test_switchable_view_string_nonsimple_lambda(browser):
 
     view = MyView(browser)
     with pytest.raises(TypeError):
-        view.the_switchable_view
+        _ = view.the_switchable_view
 
 
 def test_switchable_view_string_lambda_bad_argument_widget(browser):
@@ -680,7 +679,7 @@ def test_switchable_view_string_lambda_bad_argument_widget(browser):
 
     view = MyView(browser)
     with pytest.raises(TypeError):
-        view.the_switchable_view
+        _ = view.the_switchable_view
 
 
 def test_ignore_decorator(browser):
@@ -732,8 +731,8 @@ def test_iframe_view(browser):
     assert iframe_view.is_displayed
     assert parent_view.is_displayed
 
-    assert all([getattr(iframe_view, name).is_displayed for name in iframe_view.widget_names])
-    assert all([getattr(parent_view, name).is_displayed for name in parent_view.widget_names])
+    assert all(getattr(iframe_view, name).is_displayed for name in iframe_view.widget_names)
+    assert all(getattr(parent_view, name).is_displayed for name in parent_view.widget_names)
 
     assert iframe_view.h3.text == "IFrame Tests"
     assert parent_view.h3.text == "footest"

--- a/testing/test_widget.py
+++ b/testing/test_widget.py
@@ -1,8 +1,6 @@
 import pytest
 
-from widgetastic.widget import View
-from widgetastic.widget import Widget
-from widgetastic.widget import WidgetDescriptor
+from widgetastic.widget import View, Widget, WidgetDescriptor
 
 
 def test_widget_correctly_collapses_to_descriptor(browser):
@@ -21,7 +19,7 @@ def test_widget_broken_browser(browser):
     w.parent = object()
 
     with pytest.raises(ValueError):
-        w.browser
+        _ = w.browser
 
 
 def test_widget_with_parent_view(browser):

--- a/testing/test_widget_descriptor.py
+++ b/testing/test_widget_descriptor.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from widgetastic.widget import WidgetDescriptor
 
 
@@ -27,7 +29,7 @@ def test_descriptor_on_class():
             self.parent = parent
 
     class HostClass:
-        _desc_name_mapping = {}
+        _desc_name_mapping: ClassVar[dict] = {}
 
         def __init__(self):
             self._widget_cache = {}

--- a/testing/test_xpath.py
+++ b/testing/test_xpath.py
@@ -1,7 +1,6 @@
 import pytest
 
-from widgetastic.xpath import normalize_space
-from widgetastic.xpath import quote
+from widgetastic.xpath import normalize_space, quote
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove explicit disabling of strict-naming for wheel and sdist Hatch build targets so distributions use strict naming defaults.